### PR TITLE
feat: タブ切り替え時にウィンドウを画面いっぱいに最大化

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -47,6 +47,11 @@ fn close_editor_window(bundle_id: &str, window_id: u32) -> Result<(), String> {
 }
 
 #[tauri::command(rename_all = "snake_case")]
+fn maximize_editor_window(bundle_id: &str, window_id: u32, tab_bar_height: f64) -> Result<(), String> {
+    window_offset::maximize_window(bundle_id, window_id, tab_bar_height)
+}
+
+#[tauri::command(rename_all = "snake_case")]
 fn is_editor_active() -> bool {
     editor::is_editor_active()
 }
@@ -208,6 +213,7 @@ pub fn run() {
             focus_editor_window,
             open_new_editor,
             close_editor_window,
+            maximize_editor_window,
             is_editor_active,
             // File operations
             open_file_in_default_app,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -552,9 +552,11 @@ function App() {
       }
       waitingTimersRef.current.clear();
 
-      invoke("focus_editor_window", { bundle_id: bundleId, window_id: window.id }).catch((error) => {
-        console.error("Failed to focus window:", error);
-      });
+      invoke("focus_editor_window", { bundle_id: bundleId, window_id: window.id })
+        .then(() => invoke("maximize_editor_window", { bundle_id: bundleId, window_id: window.id, tab_bar_height: TAB_BAR_HEIGHT }))
+        .catch((error) => {
+          console.error("Failed to focus/maximize window:", error);
+        });
     }
   }, []);
 
@@ -713,7 +715,8 @@ function App() {
           const win = windowsRef.current[event.payload];
           const bundleId = currentBundleIdRef.current;
           if (win && bundleId) {
-            invoke("focus_editor_window", { bundle_id: bundleId, window_id: win.id });
+            invoke("focus_editor_window", { bundle_id: bundleId, window_id: win.id })
+              .then(() => invoke("maximize_editor_window", { bundle_id: bundleId, window_id: win.id, tab_bar_height: TAB_BAR_HEIGHT }));
           }
         }
       });


### PR DESCRIPTION
## Summary
- タブクリックおよびCmd+1-9ショートカットでタブを切り替えた際、エディタウィンドウを画面の可視領域にリサイズする機能を追加
- 外部ディスプレイ切り替え後にウィンドウが小さいままになる問題を解決
- NSScreen.visibleFrame()を使用し、メニューバー・タブバー・Dockを考慮した正確な座標計算

## Test plan
- [ ] タブクリックでウィンドウが画面いっぱいになること
- [ ] Cmd+1-9でも同様に最大化されること
- [ ] Dockの位置（左/右/下）を変えて正しく動作すること
- [ ] macOSフルスクリーン中のウィンドウには影響しないこと
- [ ] 既存のウィンドウオフセット機能が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)