### PR TITLE
feat: support Git worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 - [Installation](#installation)
 - [Usage](#usage)
   - [Keyboard Shortcuts](#keyboard-shortcuts)
+  - [Git Worktrees](#git-worktrees)
   - [Claude Code Integration](#claude-code-integration)
   - [Settings](#settings)
 - [Development](#development)
@@ -57,6 +58,7 @@ While [multi-root workspaces](https://code.visualstudio.com/docs/editing/workspa
 - **Tab Bar UI** - View all editor windows in an always-visible tab bar
 - **Quick Switching** - Switch tabs instantly with `Cmd+1` through `Cmd+9`
 - **Multi-Editor Support** - Works with VSCode, Cursor, Zed, Codex, and Claude
+- **Git Worktree Grouping** - Groups linked worktrees under one repository tab, even across editors
 - **Custom Tab Order** - Drag and drop to reorder tabs; order persists across restarts
 - **Custom Tab Colors** - Right-click a tab to assign a color for visual grouping
 - **Claude Code Integration** - Badge notifications for Claude Code task status
@@ -118,6 +120,12 @@ pnpm tauri build
 ### Menu Bar
 
 The app runs in the menu bar. Click the tray icon to access settings or quit the app.
+
+### Git Worktrees
+
+Windows opened from linked Git worktrees are grouped under a single repository tab. Click the repository tab to view its branches, switch to a worktree window, or close it.
+
+Worktrees that belong to the same repository stay grouped even when they are open in different supported editors.
 
 ### Claude Code Integration
 

--- a/src-tauri/src/editor.rs
+++ b/src-tauri/src/editor.rs
@@ -22,6 +22,8 @@ pub struct EditorWindow {
     pub name: String,
     pub path: String,
     pub branch: Option<String>,  // Git branch name
+    pub repository_id: Option<String>,
+    pub repository_name: Option<String>,
     pub bundle_id: String,       // Editor's macOS bundle ID
     pub editor_name: String,     // Editor display name (e.g. "Visual Studio Code")
 }
@@ -113,9 +115,9 @@ pub fn get_editor_state_with_config(config: &EditorConfig) -> EditorState {
         let name = extract_project_name(title, config);
 
         let resolved_path = resolve_project_path(&name, config.id, pid, *window_id);
-        let branch = resolved_path.as_ref()
-            .and_then(|path| find_git_root(path).or(Some(path.clone())))
-            .and_then(|git_root| get_git_branch(&git_root));
+        let git_root = resolved_path.as_ref().and_then(|path| find_git_root(path));
+        let branch = git_root.as_ref().and_then(|root| get_git_branch(root));
+        let repository = git_root.as_ref().and_then(|root| get_repository_info(root));
         let path_str = resolved_path
             .map(|p| p.to_string_lossy().to_string())
             .unwrap_or_default();
@@ -125,6 +127,8 @@ pub fn get_editor_state_with_config(config: &EditorConfig) -> EditorState {
             name,
             path: path_str,
             branch,
+            repository_id: repository.as_ref().map(|(id, _)| id.clone()),
+            repository_name: repository.map(|(_, name)| name),
             bundle_id: config.bundle_id.to_string(),
             editor_name: config.display_name.to_string(),
         });
@@ -176,9 +180,9 @@ pub fn get_editor_windows_with_config(config: &EditorConfig) -> Vec<EditorWindow
             let name = extract_project_name(title, config);
 
             let resolved_path = resolve_project_path(&name, config.id, pid, *window_id);
-            let branch = resolved_path.as_ref()
-                .and_then(|path| find_git_root(path).or(Some(path.clone())))
-                .and_then(|git_root| get_git_branch(&git_root));
+            let git_root = resolved_path.as_ref().and_then(|path| find_git_root(path));
+            let branch = git_root.as_ref().and_then(|root| get_git_branch(root));
+            let repository = git_root.as_ref().and_then(|root| get_repository_info(root));
             let path_str = resolved_path
                 .map(|p| p.to_string_lossy().to_string())
                 .unwrap_or_default();
@@ -188,6 +192,8 @@ pub fn get_editor_windows_with_config(config: &EditorConfig) -> Vec<EditorWindow
                 name,
                 path: path_str,
                 branch,
+                repository_id: repository.as_ref().map(|(id, _)| id.clone()),
+                repository_name: repository.map(|(_, name)| name),
                 bundle_id: config.bundle_id.to_string(),
                 editor_name: config.display_name.to_string(),
             })
@@ -513,6 +519,40 @@ fn resolve_git_dir(git_root: &std::path::Path) -> Option<PathBuf> {
     }
 }
 
+/// Resolve the shared Git directory so linked worktrees use one repository identity.
+fn resolve_git_common_dir(git_root: &Path) -> Option<PathBuf> {
+    let git_dir = resolve_git_dir(git_root)?;
+    let common_dir_file = git_dir.join("commondir");
+    let common_dir = if common_dir_file.is_file() {
+        let content = std::fs::read_to_string(common_dir_file).ok()?;
+        let path = Path::new(content.trim());
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            git_dir.join(path)
+        }
+    } else {
+        git_dir
+    };
+
+    std::fs::canonicalize(common_dir).ok()
+}
+
+fn get_repository_info(git_root: &Path) -> Option<(String, String)> {
+    let common_dir = resolve_git_common_dir(git_root)?;
+    let repository_name = if common_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        == Some(".git")
+    {
+        common_dir.parent()?.file_name()?.to_str()?.to_string()
+    } else {
+        git_root.file_name()?.to_str()?.to_string()
+    };
+
+    Some((common_dir.to_string_lossy().to_string(), repository_name))
+}
+
 /// Read .git/HEAD to get current branch name
 /// Returns branch name for normal branches, short commit hash for detached HEAD
 /// Supports both regular repos and submodules
@@ -721,6 +761,46 @@ mod tests {
         let result = resolve_git_dir(&sub);
         assert!(result.is_some());
         assert_eq!(result.unwrap(), std::fs::canonicalize(&actual_git).unwrap());
+    }
+
+    #[test]
+    fn linked_worktree_uses_main_repository_identity() {
+        let tmp = tempfile::tempdir().unwrap();
+        let main = tmp.path().join("project");
+        let main_git = main.join(".git");
+        let worktree_git = main_git.join("worktrees/feature");
+        fs::create_dir_all(&worktree_git).unwrap();
+
+        let worktree = tmp.path().join("project-feature");
+        fs::create_dir(&worktree).unwrap();
+        fs::write(
+            worktree.join(".git"),
+            format!("gitdir: {}\n", worktree_git.display()),
+        )
+        .unwrap();
+        fs::write(worktree_git.join("commondir"), "../..\n").unwrap();
+
+        let main_info = get_repository_info(&main).unwrap();
+        let worktree_info = get_repository_info(&worktree).unwrap();
+
+        assert_eq!(main_info, worktree_info);
+        assert_eq!(main_info.1, "project");
+    }
+
+    #[test]
+    fn separate_repositories_use_different_identities() {
+        let tmp = tempfile::tempdir().unwrap();
+        let first = tmp.path().join("first");
+        let second = tmp.path().join("second");
+        fs::create_dir_all(first.join(".git")).unwrap();
+        fs::create_dir_all(second.join(".git")).unwrap();
+
+        let first_info = get_repository_info(&first).unwrap();
+        let second_info = get_repository_info(&second).unwrap();
+
+        assert_ne!(first_info.0, second_info.0);
+        assert_eq!(first_info.1, "first");
+        assert_eq!(second_info.1, "second");
     }
 
     #[test]

--- a/src-tauri/src/editor.rs
+++ b/src-tauri/src/editor.rs
@@ -2,11 +2,14 @@ use crate::ax_helper;
 use crate::editor_config::{EditorConfig, EDITORS};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 lazy_static::lazy_static! {
-    /// プロジェクト名 → フルパスのキャッシュ
-    static ref PROJECT_PATH_CACHE: std::sync::Mutex<HashMap<String, PathBuf>> =
+    /// エディタID + プロジェクト名 → フルパス候補のキャッシュ
+    static ref PROJECT_PATH_CACHE: std::sync::Mutex<HashMap<String, Vec<PathBuf>>> =
+        std::sync::Mutex::new(HashMap::new());
+    /// エディタID + ウィンドウID + プロジェクト名 → フルパスのキャッシュ
+    static ref WINDOW_PATH_CACHE: std::sync::Mutex<HashMap<(String, u32, String), PathBuf>> =
         std::sync::Mutex::new(HashMap::new());
     /// エディタIDごとの初期化フラグ
     static ref CACHE_INITIALIZED: std::sync::Mutex<HashMap<String, bool>> =
@@ -222,15 +225,16 @@ pub fn get_active_window_id() -> Option<u32> {
 ///
 /// Called by the registry when an editor's PID changes (restart), since a
 /// restart can mean workspace.json files changed while we weren't looking.
-/// `PROJECT_PATH_CACHE` is keyed by project name (not editor_id), so we clear
-/// it entirely — cheaper than introducing an editor-tagged key and the cost
-/// of a re-read is paid at most once per editor restart.
 pub fn invalidate_path_cache_for_editor(editor_id: &str) {
     if let Ok(mut initialized) = CACHE_INITIALIZED.lock() {
         initialized.remove(editor_id);
     }
     if let Ok(mut cache) = PROJECT_PATH_CACHE.lock() {
-        cache.clear();
+        let prefix = format!("{}:", editor_id);
+        cache.retain(|key, _| !key.starts_with(&prefix));
+    }
+    if let Ok(mut cache) = WINDOW_PATH_CACHE.lock() {
+        cache.retain(|(cached_editor_id, _, _), _| cached_editor_id != editor_id);
     }
 }
 
@@ -245,8 +249,18 @@ fn get_workspace_storage_dir(editor_id: &str) -> Option<PathBuf> {
     Some(home.join("Library/Application Support").join(subdir).join("User/workspaceStorage"))
 }
 
-/// workspaceStorage内の全workspace.jsonを読み取り、プロジェクト名→フルパスのマッピングを返す
-fn load_workspace_paths(editor_id: &str) -> HashMap<String, PathBuf> {
+fn add_workspace_path(map: &mut HashMap<String, Vec<PathBuf>>, path: PathBuf) {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return;
+    };
+    let paths = map.entry(name.to_string()).or_default();
+    if !paths.contains(&path) {
+        paths.push(path);
+    }
+}
+
+/// workspaceStorage内の全workspace.jsonを読み取り、プロジェクト名→フルパス候補のマッピングを返す
+fn load_workspace_paths(editor_id: &str) -> HashMap<String, Vec<PathBuf>> {
     let mut map = HashMap::new();
     let storage_dir = match get_workspace_storage_dir(editor_id) {
         Some(d) => d,
@@ -267,8 +281,8 @@ fn load_workspace_paths(editor_id: &str) -> HashMap<String, PathBuf> {
                     // URLデコード（スペースなどの%エンコード対応）
                     let decoded = percent_decode(path_str);
                     let path = PathBuf::from(&decoded);
-                    if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                        map.insert(name.to_string(), path);
+                    if path.exists() {
+                        add_workspace_path(&mut map, path);
                     }
                 }
             }
@@ -302,74 +316,126 @@ fn percent_decode(input: &str) -> String {
     String::from_utf8(bytes).unwrap_or_else(|_| input.to_string())
 }
 
-/// プロジェクト名からフルパスを解決する
-/// 1. キャッシュにあれば即返却
-/// 2. キャッシュ未初期化 → workspaceStorage から一括読み込み → 再チェック
-/// 3. フォールバック: AXDocument（前面ウィンドウでは動作）
+fn workspace_cache_key(editor_id: &str, project_name: &str) -> String {
+    format!("{}:{}", editor_id, project_name)
+}
+
+fn cache_window_path(editor_id: &str, window_id: u32, project_name: &str, path: &Path) {
+    if let Ok(mut cache) = WINDOW_PATH_CACHE.lock() {
+        cache.insert(
+            (editor_id.to_string(), window_id, project_name.to_string()),
+            path.to_path_buf(),
+        );
+    }
+}
+
+fn cache_project_path(editor_id: &str, project_name: &str, path: &Path) {
+    if let Ok(mut cache) = PROJECT_PATH_CACHE.lock() {
+        let paths = cache
+            .entry(workspace_cache_key(editor_id, project_name))
+            .or_default();
+        if !paths.iter().any(|cached_path| cached_path == path) {
+            paths.push(path.to_path_buf());
+        }
+    }
+}
+
+fn ensure_workspace_paths_loaded(editor_id: &str) -> Option<()> {
+    let mut initialized = CACHE_INITIALIZED.lock().ok()?;
+    if initialized.get(editor_id).copied().unwrap_or(false) {
+        return Some(());
+    }
+
+    let paths = load_workspace_paths(editor_id);
+    let mut cache = PROJECT_PATH_CACHE.lock().ok()?;
+    for (name, candidate_paths) in paths {
+        let cached_paths = cache
+            .entry(workspace_cache_key(editor_id, &name))
+            .or_default();
+        for path in candidate_paths {
+            if !cached_paths.contains(&path) {
+                cached_paths.push(path);
+            }
+        }
+    }
+    initialized.insert(editor_id.to_string(), true);
+    Some(())
+}
+
+fn workspace_path_for_document(candidates: &[PathBuf], document_path: &Path) -> Option<PathBuf> {
+    candidates
+        .iter()
+        .filter(|candidate| document_path.starts_with(candidate))
+        .max_by_key(|candidate| candidate.components().count())
+        .cloned()
+}
+
+/// プロジェクト名とウィンドウ情報からフルパスを解決する
 fn resolve_project_path(
     project_name: &str,
     editor_id: &str,
     pid: i32,
     window_id: u32,
 ) -> Option<PathBuf> {
-    // 1. キャッシュから検索
-    {
+    let document_path = ax_helper::get_document_path(pid, window_id).map(PathBuf::from);
+    ensure_workspace_paths_loaded(editor_id)?;
+
+    let project_paths = {
         let cache = PROJECT_PATH_CACHE.lock().ok()?;
-        if let Some(path) = cache.get(project_name) {
+        cache
+            .get(&workspace_cache_key(editor_id, project_name))
+            .cloned()
+            .unwrap_or_default()
+    };
+
+    if let Some(document_path) = document_path {
+        // ドキュメントを内包するワークスペースを選び、同名ワークツリーやサブモジュールを区別する
+        if let Some(workspace_path) = workspace_path_for_document(&project_paths, &document_path) {
+            cache_window_path(editor_id, window_id, project_name, &workspace_path);
+            return Some(workspace_path);
+        }
+        if let Some(git_root) = find_git_root(&document_path) {
+            cache_window_path(editor_id, window_id, project_name, &git_root);
+            cache_project_path(editor_id, project_name, &git_root);
+            return Some(git_root);
+        }
+    }
+
+    let window_cache_key = (editor_id.to_string(), window_id, project_name.to_string());
+    {
+        let cache = WINDOW_PATH_CACHE.lock().ok()?;
+        if let Some(path) = cache.get(&window_cache_key) {
             return Some(path.clone());
         }
     }
 
-    // 2. キャッシュ未初期化ならworkspaceStorageから読み込み
-    {
-        let mut initialized = CACHE_INITIALIZED.lock().ok()?;
-        if !initialized.get(editor_id).copied().unwrap_or(false) {
-            let paths = load_workspace_paths(editor_id);
-            let mut cache = PROJECT_PATH_CACHE.lock().ok()?;
-            for (name, path) in paths {
-                cache.entry(name).or_insert(path);
-            }
-            initialized.insert(editor_id.to_string(), true);
-        }
+    if project_paths.len() == 1 {
+        let path = project_paths[0].clone();
+        cache_window_path(editor_id, window_id, project_name, &path);
+        return Some(path);
     }
 
-    // キャッシュを再チェック
-    {
-        let cache = PROJECT_PATH_CACHE.lock().ok()?;
-        if let Some(path) = cache.get(project_name) {
-            return Some(path.clone());
-        }
-    }
-
-    // 3. キャッシュ済みパスのサブディレクトリを検索（サブモジュール等）
     {
         let parent_paths: Vec<PathBuf> = {
             let cache = PROJECT_PATH_CACHE.lock().ok()?;
-            cache.values().cloned().collect()
+            let prefix = format!("{}:", editor_id);
+            cache
+                .iter()
+                .filter(|(key, _)| key.starts_with(&prefix))
+                .flat_map(|(_, paths)| paths.iter().cloned())
+                .collect()
         };
         for parent_path in &parent_paths {
             let candidate = parent_path.join(project_name);
             if candidate.is_dir() && candidate.join(".git").exists() {
-                if let Ok(mut cache) = PROJECT_PATH_CACHE.lock() {
-                    cache.insert(project_name.to_string(), candidate.clone());
-                }
+                cache_window_path(editor_id, window_id, project_name, &candidate);
+                cache_project_path(editor_id, project_name, &candidate);
                 return Some(candidate);
             }
         }
     }
 
-    // 4. フォールバック: AXDocument
-    let doc_path = ax_helper::get_document_path(pid, window_id)?;
-    let path = PathBuf::from(&doc_path);
-    let parent = path.parent()?;
-    let git_root = find_git_root(parent)?;
-
-    // 成功時はキャッシュに追加
-    if let Ok(mut cache) = PROJECT_PATH_CACHE.lock() {
-        cache.insert(project_name.to_string(), git_root.clone());
-    }
-
-    Some(git_root)
+    None
 }
 
 /// Extract project name from editor window title
@@ -536,6 +602,23 @@ mod tests {
     }
 
     #[test]
+    fn find_git_root_from_file_in_worktree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let worktree = tmp.path().join("worktrees/project");
+        let source_dir = worktree.join("src");
+        fs::create_dir_all(&source_dir).unwrap();
+        fs::write(
+            worktree.join(".git"),
+            "gitdir: /tmp/repo/.git/worktrees/project\n",
+        )
+        .unwrap();
+        let source_file = source_dir.join("main.rs");
+        fs::write(&source_file, "fn main() {}\n").unwrap();
+
+        assert_eq!(find_git_root(&source_file), Some(worktree));
+    }
+
+    #[test]
     fn get_git_branch_normal() {
         let tmp = tempfile::tempdir().unwrap();
         let git_dir = tmp.path().join(".git");
@@ -590,6 +673,27 @@ mod tests {
 
         let result = get_git_branch(&sub_dir);
         assert_eq!(result, Some("develop".to_string()));
+    }
+
+    #[test]
+    fn get_git_branch_worktree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let git_dir = tmp.path().join("main/.git/worktrees/feature");
+        fs::create_dir_all(&git_dir).unwrap();
+        fs::write(git_dir.join("HEAD"), "ref: refs/heads/feature/worktree\n").unwrap();
+
+        let worktree = tmp.path().join("worktrees/project");
+        fs::create_dir_all(&worktree).unwrap();
+        fs::write(
+            worktree.join(".git"),
+            format!("gitdir: {}\n", git_dir.display()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            get_git_branch(&worktree),
+            Some("feature/worktree".to_string())
+        );
     }
 
     #[test]
@@ -650,5 +754,28 @@ mod tests {
 
         let zed_dir = get_workspace_storage_dir("zed");
         assert!(zed_dir.is_none());
+    }
+
+    #[test]
+    fn workspace_paths_keep_same_named_worktrees() {
+        let mut paths = HashMap::new();
+        add_workspace_path(&mut paths, PathBuf::from("/worktrees/one/project"));
+        add_workspace_path(&mut paths, PathBuf::from("/worktrees/two/project"));
+
+        assert_eq!(paths.get("project").unwrap().len(), 2);
+    }
+
+    #[test]
+    fn workspace_path_matches_document_in_same_named_worktree() {
+        let candidates = vec![
+            PathBuf::from("/worktrees/one/project"),
+            PathBuf::from("/worktrees/two/project"),
+        ];
+        let document = PathBuf::from("/worktrees/two/project/modules/api/src/lib.rs");
+
+        assert_eq!(
+            workspace_path_for_document(&candidates, &document),
+            Some(PathBuf::from("/worktrees/two/project"))
+        );
     }
 }

--- a/src-tauri/src/editor.rs
+++ b/src-tauri/src/editor.rs
@@ -5,10 +5,10 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 lazy_static::lazy_static! {
-    /// エディタID + プロジェクト名 → フルパス候補のキャッシュ
+    /// Editor ID + project name -> full path candidates
     static ref PROJECT_PATH_CACHE: std::sync::Mutex<HashMap<String, Vec<PathBuf>>> =
         std::sync::Mutex::new(HashMap::new());
-    /// エディタID + ウィンドウID + プロジェクト名 → フルパスのキャッシュ
+    /// Editor ID + window ID + project name -> full path
     static ref WINDOW_PATH_CACHE: std::sync::Mutex<HashMap<(String, u32, String), PathBuf>> =
         std::sync::Mutex::new(HashMap::new());
     /// エディタIDごとの初期化フラグ
@@ -259,7 +259,7 @@ fn add_workspace_path(map: &mut HashMap<String, Vec<PathBuf>>, path: PathBuf) {
     }
 }
 
-/// workspaceStorage内の全workspace.jsonを読み取り、プロジェクト名→フルパス候補のマッピングを返す
+/// Read workspace.json files and map project names to full path candidates
 fn load_workspace_paths(editor_id: &str) -> HashMap<String, Vec<PathBuf>> {
     let mut map = HashMap::new();
     let storage_dir = match get_workspace_storage_dir(editor_id) {
@@ -370,7 +370,7 @@ fn workspace_path_for_document(candidates: &[PathBuf], document_path: &Path) -> 
         .cloned()
 }
 
-/// プロジェクト名とウィンドウ情報からフルパスを解決する
+/// Resolve a full path from the project name and window metadata
 fn resolve_project_path(
     project_name: &str,
     editor_id: &str,
@@ -389,7 +389,7 @@ fn resolve_project_path(
     };
 
     if let Some(document_path) = document_path {
-        // ドキュメントを内包するワークスペースを選び、同名ワークツリーやサブモジュールを区別する
+        // Use the containing workspace to distinguish same-named worktrees and submodules
         if let Some(workspace_path) = workspace_path_for_document(&project_paths, &document_path) {
             cache_window_path(editor_id, window_id, project_name, &workspace_path);
             return Some(workspace_path);

--- a/src-tauri/src/window_registry.rs
+++ b/src-tauri/src/window_registry.rs
@@ -304,4 +304,14 @@ mod tests {
         }];
         assert!(windows_differ(&a, &b));
     }
+
+    #[test]
+    fn repository_identity_change_is_detected() {
+        let a = vec![mk(1, "project", "b1")];
+        let mut resolved = mk(1, "project", "b1");
+        resolved.repository_id = Some("/projects/project/.git".into());
+        resolved.repository_name = Some("project".into());
+
+        assert!(windows_differ(&a, &[resolved]));
+    }
 }

--- a/src-tauri/src/window_registry.rs
+++ b/src-tauri/src/window_registry.rs
@@ -229,6 +229,8 @@ fn windows_differ(a: &[EditorWindow], b: &[EditorWindow]) -> bool {
                 || wa.name != wb.name
                 || wa.branch != wb.branch
                 || wa.path != wb.path
+                || wa.repository_id != wb.repository_id
+                || wa.repository_name != wb.repository_name
                 || wa.bundle_id != wb.bundle_id
         })
 }
@@ -243,6 +245,8 @@ mod tests {
             name: name.to_string(),
             path: String::new(),
             branch: None,
+            repository_id: None,
+            repository_name: None,
             bundle_id: bundle.to_string(),
             editor_name: String::new(),
         }
@@ -283,6 +287,8 @@ mod tests {
             name: "p".into(),
             path: String::new(),
             branch: Some("main".into()),
+            repository_id: None,
+            repository_name: None,
             bundle_id: "b1".into(),
             editor_name: String::new(),
         }];
@@ -291,6 +297,8 @@ mod tests {
             name: "p".into(),
             path: String::new(),
             branch: Some("dev".into()),
+            repository_id: None,
+            repository_name: None,
             bundle_id: "b1".into(),
             editor_name: String::new(),
         }];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -129,8 +129,8 @@ function App() {
       onAddGroup={editorWindows.addGroup}
       onUpdateGroup={editorWindows.updateGroup}
       onDeleteGroup={editorWindows.deleteGroup}
-      onAssignTabToGroup={editorWindows.assignTabToGroup}
-      onUnassignTabFromGroup={editorWindows.unassignTabFromGroup}
+      onAssignTabsToGroup={editorWindows.assignTabsToGroup}
+      onUnassignTabsFromGroup={editorWindows.unassignTabsFromGroup}
       onToggleGroupCollapse={editorWindows.toggleGroupCollapse}
       onReorderGroups={editorWindows.reorderGroups}
       groupColors={editorWindows.groupColors}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,6 +137,8 @@ function App() {
       onSetGroupColor={editorWindows.setGroupColor}
       onTabContextMenuOpen={lifecycle.handleTabContextMenuOpen}
       onTabContextMenuClose={lifecycle.handleTabContextMenuClose}
+      onWorktreeMenuOpen={lifecycle.handleWorktreeMenuOpen}
+      onWorktreeMenuClose={lifecycle.handleWorktreeMenuClose}
     />
   );
 }

--- a/src/components/AddTabMenu.tsx
+++ b/src/components/AddTabMenu.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import type { EditorWindow, HistoryEntry } from "../types/editor";
+import { normalizeProjectPath, windowKey } from "../utils/store";
 
 interface AddTabMenuProps {
   entries: HistoryEntry[];
@@ -30,8 +31,10 @@ function AddTabMenu({ entries, currentWindows, onNewWindow, onSelectHistory, onC
   const menuRef = useRef<HTMLDivElement>(null);
 
   // Filter out currently open tabs from history
-  const currentNames = new Set(currentWindows.map(w => w.name));
-  const filteredEntries = entries.filter(e => !currentNames.has(e.name));
+  const currentWindowKeys = new Set(currentWindows.map(windowKey));
+  const filteredEntries = entries.filter(
+    (entry) => !currentWindowKeys.has(`${entry.bundleId}:${normalizeProjectPath(entry.path)}`)
+  );
 
   // Calculate position from anchor button
   useEffect(() => {

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type { EditorWindow } from "../types/editor";
-import { windowKey } from "../utils/store";
+import { repositoryColorKey, windowKey } from "../utils/store";
 import TabBar from "./TabBar";
 
 const cursorWindow: EditorWindow = {
@@ -25,8 +25,9 @@ const vscodeWorktree: EditorWindow = {
   editor_name: "VSCode",
 };
 
-function setup() {
+function setup(tabColors: Record<string, string | null> = {}) {
   const onAssignTabsToGroup = vi.fn();
+  const onColorChange = vi.fn();
   const props = {
     tabs: [cursorWindow, vscodeWorktree],
     activeIndex: 0,
@@ -43,6 +44,8 @@ function setup() {
     onHistoryClear: vi.fn(),
     onColorPickerOpen: vi.fn().mockResolvedValue(undefined),
     onColorPickerClose: vi.fn(),
+    tabColors,
+    onColorChange,
     groups: [
       { id: "medii", name: "medii", order: 0 },
       { id: "personal", name: "personal", order: 1 },
@@ -65,7 +68,7 @@ function setup() {
   };
 
   render(<TabBar {...props} />);
-  return { props, onAssignTabsToGroup };
+  return { props, onAssignTabsToGroup, onColorChange };
 }
 
 describe("TabBar repository grouping", () => {
@@ -106,5 +109,19 @@ describe("TabBar repository grouping", () => {
         "personal",
       );
     });
+  });
+
+  it("stores and displays a color for the aggregate repository tab", async () => {
+    const colorKey = repositoryColorKey(cursorWindow.repository_id!);
+    const { onColorChange } = setup({ [colorKey]: "red" });
+    const trigger = screen.getByRole("button", { name: "worktree.openBranches" });
+
+    expect(trigger).toHaveStyle({ background: "rgb(110, 81, 83)" });
+
+    fireEvent.contextMenu(trigger);
+    fireEvent.click(await screen.findByRole("button", { name: "tabColor.title" }));
+    fireEvent.click(await screen.findByTitle("tabColor.blue"));
+
+    expect(onColorChange).toHaveBeenCalledWith(colorKey, "blue");
   });
 });

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -1,0 +1,110 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import type { EditorWindow } from "../types/editor";
+import { windowKey } from "../utils/store";
+import TabBar from "./TabBar";
+
+const cursorWindow: EditorWindow = {
+  id: 1,
+  name: "medii-e-consult-front",
+  path: "/Users/test/projects/medii-e-consult-front",
+  branch: "main",
+  repository_id: "/Users/test/projects/medii-e-consult-front/.git",
+  repository_name: "medii-e-consult-front",
+  bundle_id: "com.todesktop.230313mzl4w4u92",
+  editor_name: "Cursor",
+};
+
+const vscodeWorktree: EditorWindow = {
+  id: 2,
+  name: "medii-e-consult-front",
+  path: "/Users/test/.codex/worktrees/a1b2/medii-e-consult-front",
+  branch: "feature/search",
+  repository_id: "/Users/test/projects/medii-e-consult-front/.git",
+  repository_name: "medii-e-consult-front",
+  bundle_id: "com.microsoft.VSCode",
+  editor_name: "VSCode",
+};
+
+function setup() {
+  const onAssignTabsToGroup = vi.fn();
+  const props = {
+    tabs: [cursorWindow, vscodeWorktree],
+    activeIndex: 0,
+    onTabClick: vi.fn(),
+    onNewTab: vi.fn(),
+    onCloseTab: vi.fn(),
+    onReorder: vi.fn(),
+    onReorderByVisual: vi.fn(),
+    history: [],
+    showAddMenu: false,
+    onAddMenuOpen: vi.fn(),
+    onAddMenuClose: vi.fn(),
+    onHistorySelect: vi.fn(),
+    onHistoryClear: vi.fn(),
+    onColorPickerOpen: vi.fn().mockResolvedValue(undefined),
+    onColorPickerClose: vi.fn(),
+    groups: [
+      { id: "medii", name: "medii", order: 0 },
+      { id: "personal", name: "personal", order: 1 },
+    ],
+    groupAssignments: { [windowKey(cursorWindow)]: "medii" },
+    collapsedGroups: new Set<string>(),
+    onAddGroup: vi.fn(() => "new-group"),
+    onUpdateGroup: vi.fn(),
+    onDeleteGroup: vi.fn(),
+    onAssignTabsToGroup,
+    onUnassignTabsFromGroup: vi.fn(),
+    onToggleGroupCollapse: vi.fn(),
+    onReorderGroups: vi.fn(),
+    groupColors: {},
+    onSetGroupColor: vi.fn(),
+    onTabContextMenuOpen: vi.fn().mockResolvedValue(undefined),
+    onTabContextMenuClose: vi.fn().mockResolvedValue(undefined),
+    onWorktreeMenuOpen: vi.fn().mockResolvedValue(undefined),
+    onWorktreeMenuClose: vi.fn().mockResolvedValue(undefined),
+  };
+
+  render(<TabBar {...props} />);
+  return { props, onAssignTabsToGroup };
+}
+
+describe("TabBar repository grouping", () => {
+  beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: vi.fn(),
+    });
+  });
+
+  it("groups the same repository across editors and inherits its only manual group", () => {
+    setup();
+
+    const groupLabel = screen.getByRole("button", { name: "medii" });
+    const group = groupLabel.closest(".tab-group");
+
+    expect(group).not.toBeNull();
+    expect(within(group as HTMLElement).getByRole("button", {
+      name: "worktree.openBranches",
+    })).toBeInTheDocument();
+  });
+
+  it("assigns every repository window from the parent context menu", async () => {
+    const { onAssignTabsToGroup } = setup();
+    const trigger = screen.getByRole("button", { name: "worktree.openBranches" });
+
+    fireEvent.contextMenu(trigger);
+    const assignButton = await screen.findByRole("button", {
+      name: "group.assignToGroup ▶",
+    });
+    fireEvent.mouseEnter(assignButton.parentElement as HTMLElement);
+    const submenu = document.querySelector(".group-submenu");
+    fireEvent.click(within(submenu as HTMLElement).getByRole("button", { name: "personal" }));
+
+    await waitFor(() => {
+      expect(onAssignTabsToGroup).toHaveBeenCalledWith(
+        [windowKey(cursorWindow), windowKey(vscodeWorktree)],
+        "personal",
+      );
+    });
+  });
+});

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -7,7 +7,7 @@ import AddTabMenu from "./AddTabMenu";
 import type { EditorWindow, ClaudeStatus, HistoryEntry, GroupDefinition, GroupAssignment, TabColorMap } from "../types/editor";
 import { getWindowScopedValue, legacyWindowKey, projectPathMatchesWindow, windowKey } from "../utils/store";
 import { getColorById } from "../constants/tabColors";
-import { groupRepositoryTabs, type TabEntry } from "../utils/repositoryTabs";
+import { getInheritedRepositoryGroupId, groupRepositoryTabs, type TabEntry } from "../utils/repositoryTabs";
 
 interface TabBarProps {
   tabs: EditorWindow[];
@@ -35,8 +35,8 @@ interface TabBarProps {
   onAddGroup: (name: string) => string;
   onUpdateGroup: (groupId: string, name: string) => void;
   onDeleteGroup: (groupId: string) => void;
-  onAssignTabToGroup: (wKey: string, groupId: string) => void;
-  onUnassignTabFromGroup: (wKey: string) => void;
+  onAssignTabsToGroup: (wKeys: string[], groupId: string) => void;
+  onUnassignTabsFromGroup: (wKeys: string[]) => void;
   onToggleGroupCollapse: (groupId: string) => void;
   onReorderGroups: (fromIndex: number, toIndex: number) => void;
   groupColors: Record<string, string>;
@@ -59,7 +59,7 @@ const getClaudeStatusForTab = (tab: EditorWindow, statuses?: Record<string, Clau
 };
 
 function TabBar(props: TabBarProps) {
-  const { tabs, activeIndex, onTabClick, onNewTab, onCloseTab, onReorder, onReorderByVisual, claudeStatuses, tabColors, onColorChange, showBranch, history, showAddMenu, onAddMenuOpen, onAddMenuClose, onHistorySelect, onHistoryClear, onColorPickerOpen, onColorPickerClose, groups, groupAssignments, collapsedGroups, onAddGroup, onUpdateGroup, onDeleteGroup, onAssignTabToGroup, onUnassignTabFromGroup, onToggleGroupCollapse, onReorderGroups, groupColors, onSetGroupColor, onTabContextMenuOpen, onTabContextMenuClose, onWorktreeMenuOpen, onWorktreeMenuClose } = props;
+  const { tabs, activeIndex, onTabClick, onNewTab, onCloseTab, onReorder, onReorderByVisual, claudeStatuses, tabColors, onColorChange, showBranch, history, showAddMenu, onAddMenuOpen, onAddMenuClose, onHistorySelect, onHistoryClear, onColorPickerOpen, onColorPickerClose, groups, groupAssignments, collapsedGroups, onAddGroup, onUpdateGroup, onDeleteGroup, onAssignTabsToGroup, onUnassignTabsFromGroup, onToggleGroupCollapse, onReorderGroups, groupColors, onSetGroupColor, onTabContextMenuOpen, onTabContextMenuClose, onWorktreeMenuOpen, onWorktreeMenuClose } = props;
   const { t } = useTranslation();
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
   const [colorPickerTarget, setColorPickerTarget] = useState<number | null>(null);
@@ -68,7 +68,7 @@ function TabBar(props: TabBarProps) {
   const [editingGroupId, setEditingGroupId] = useState<string | null>(null);
   const [editingGroupName, setEditingGroupName] = useState("");
   const [draggedGroupIndex, setDraggedGroupIndex] = useState<number | null>(null);
-  const [tabContextMenu, setTabContextMenu] = useState<{ index: number; x: number; y: number; rect: DOMRect } | null>(null);
+  const [tabContextMenu, setTabContextMenu] = useState<{ index: number; indices: number[]; x: number; y: number; rect: DOMRect } | null>(null);
   const [groupSubmenuOpen, setGroupSubmenuOpen] = useState(false);
   const [newGroupInput, setNewGroupInput] = useState<string | null>(null);
   const [groupColorPickerTarget, setGroupColorPickerTarget] = useState<string | null>(null);
@@ -112,7 +112,22 @@ function TabBar(props: TabBarProps) {
 
   const handleTabContextMenu = useCallback(async (index: number, rect: DOMRect) => {
     await onTabContextMenuOpen();
-    setTabContextMenu({ index, x: rect.left, y: rect.bottom, rect });
+    setTabContextMenu({ index, indices: [index], x: rect.left, y: rect.bottom, rect });
+  }, [onTabContextMenuOpen]);
+
+  const handleWorktreeContextMenu = useCallback(async (
+    indices: number[],
+    preferredIndex: number,
+    rect: DOMRect,
+  ) => {
+    await onTabContextMenuOpen();
+    setTabContextMenu({
+      index: preferredIndex,
+      indices,
+      x: rect.left,
+      y: rect.bottom,
+      rect,
+    });
   }, [onTabContextMenuOpen]);
 
   const handleOpenColorPicker = useCallback(async () => {
@@ -155,35 +170,38 @@ function TabBar(props: TabBarProps) {
 
   const handleAssignToGroup = useCallback((groupId: string) => {
     if (tabContextMenu) {
-      const tab = tabs[tabContextMenu.index];
-      if (tab) {
-        onAssignTabToGroup(windowKey(tab), groupId);
-      }
+      const keys = tabContextMenu.indices
+        .map((index) => tabs[index])
+        .filter((tab): tab is EditorWindow => Boolean(tab))
+        .map(windowKey);
+      onAssignTabsToGroup(keys, groupId);
     }
     closeTabContextMenu();
-  }, [tabContextMenu, tabs, onAssignTabToGroup, closeTabContextMenu]);
+  }, [tabContextMenu, tabs, onAssignTabsToGroup, closeTabContextMenu]);
 
   const handleUnassignFromGroup = useCallback(() => {
     if (tabContextMenu) {
-      const tab = tabs[tabContextMenu.index];
-      if (tab) {
-        onUnassignTabFromGroup(windowKey(tab));
-      }
+      const keys = tabContextMenu.indices
+        .map((index) => tabs[index])
+        .filter((tab): tab is EditorWindow => Boolean(tab))
+        .map(windowKey);
+      onUnassignTabsFromGroup(keys);
     }
     closeTabContextMenu();
-  }, [tabContextMenu, tabs, onUnassignTabFromGroup, closeTabContextMenu]);
+  }, [tabContextMenu, tabs, onUnassignTabsFromGroup, closeTabContextMenu]);
 
   const handleCreateNewGroup = useCallback(() => {
     if (newGroupInput !== null && newGroupInput.trim() && tabContextMenu) {
       const groupId = onAddGroup(newGroupInput.trim());
-      const tab = tabs[tabContextMenu.index];
-      if (tab) {
-        onAssignTabToGroup(windowKey(tab), groupId);
-      }
+      const keys = tabContextMenu.indices
+        .map((index) => tabs[index])
+        .filter((tab): tab is EditorWindow => Boolean(tab))
+        .map(windowKey);
+      onAssignTabsToGroup(keys, groupId);
     }
     setNewGroupInput(null);
     closeTabContextMenu();
-  }, [newGroupInput, onAddGroup, tabContextMenu, tabs, onAssignTabToGroup, closeTabContextMenu]);
+  }, [newGroupInput, onAddGroup, tabContextMenu, tabs, onAssignTabsToGroup, closeTabContextMenu]);
 
   // Group label context menu
   const handleGroupLabelContextMenu = useCallback(async (e: React.MouseEvent, groupId: string) => {
@@ -267,9 +285,25 @@ function TabBar(props: TabBarProps) {
     const groupIds = new Set(groups.map((g) => g.id));
     const grouped = new Map<string, { tab: EditorWindow; originalIndex: number }[]>();
     const ungrouped: { tab: EditorWindow; originalIndex: number }[] = [];
+    const allEntries = tabs.map((tab, originalIndex) => ({ tab, originalIndex }));
+    const repositoryGroupByIndex = new Map<number, string | null>();
+
+    for (const item of groupRepositoryTabs(allEntries)) {
+      if (item.type !== "repository") continue;
+      const inheritedGroupId = getInheritedRepositoryGroupId(item.entries, ({ tab }) => {
+        const groupId = getWindowScopedValue(groupAssignments, tab, legacyWindowKey(tab));
+        return groupId && groupIds.has(groupId) ? groupId : null;
+      });
+      for (const { originalIndex } of item.entries) {
+        repositoryGroupByIndex.set(originalIndex, inheritedGroupId);
+      }
+    }
 
     tabs.forEach((tab, index) => {
-      const groupId = getWindowScopedValue(groupAssignments, tab, legacyWindowKey(tab));
+      const assignedGroupId = getWindowScopedValue(groupAssignments, tab, legacyWindowKey(tab));
+      const groupId = repositoryGroupByIndex.has(index)
+        ? repositoryGroupByIndex.get(index)
+        : assignedGroupId;
       if (groupId && groupIds.has(groupId)) {
         if (!grouped.has(groupId)) {
           grouped.set(groupId, []);
@@ -364,7 +398,7 @@ function TabBar(props: TabBarProps) {
         onCloseTab={handleCloseTab}
         onMenuOpen={onWorktreeMenuOpen}
         onMenuClose={onWorktreeMenuClose}
-        onContextMenu={handleTabContextMenu}
+        onContextMenu={handleWorktreeContextMenu}
       />
     );
   });
@@ -578,11 +612,14 @@ function TabBar(props: TabBarProps) {
                       {t("group.createNew")}
                     </button>
                   )}
-                  {tabContextMenu && tabs[tabContextMenu.index] && getWindowScopedValue(
-                    groupAssignments,
-                    tabs[tabContextMenu.index],
-                    legacyWindowKey(tabs[tabContextMenu.index]),
-                  ) && (
+                  {tabContextMenu && tabContextMenu.indices.some((index) => {
+                    const tab = tabs[index];
+                    return tab && getWindowScopedValue(
+                      groupAssignments,
+                      tab,
+                      legacyWindowKey(tab),
+                    );
+                  }) && (
                     <>
                       <div style={styles.contextMenuSeparator} />
                       <button

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -3,8 +3,8 @@ import { useTranslation } from "react-i18next";
 import Tab from "./Tab";
 import ColorPicker from "./ColorPicker";
 import AddTabMenu from "./AddTabMenu";
-import type { EditorWindow, ClaudeStatus, HistoryEntry, GroupDefinition, GroupAssignment } from "../types/editor";
-import { windowKey } from "../utils/store";
+import type { EditorWindow, ClaudeStatus, HistoryEntry, GroupDefinition, GroupAssignment, TabColorMap } from "../types/editor";
+import { getWindowScopedValue, legacyWindowKey, projectPathMatchesWindow, windowKey } from "../utils/store";
 import { getColorById } from "../constants/tabColors";
 
 interface TabBarProps {
@@ -16,8 +16,8 @@ interface TabBarProps {
   onReorder: (fromIndex: number, toIndex: number) => void;
   onReorderByVisual: (visualOrder: number[]) => void;
   claudeStatuses?: Record<string, ClaudeStatus>;
-  tabColors?: Record<string, string>;
-  onColorChange?: (windowName: string, colorId: string | null) => void;
+  tabColors?: TabColorMap;
+  onColorChange?: (windowKey: string, colorId: string | null) => void;
   showBranch?: boolean;
   history: HistoryEntry[];
   showAddMenu: boolean;
@@ -43,15 +43,13 @@ interface TabBarProps {
   onTabContextMenuClose: () => Promise<void>;
 }
 
-// フルパスからプロジェクト名を抽出してマッチング
 const toRgba = (rgb: { r: number; g: number; b: number }, alpha: number) =>
   `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${alpha})`;
 
-const getClaudeStatusForTab = (tabName: string, statuses?: Record<string, ClaudeStatus>) => {
+const getClaudeStatusForTab = (tab: EditorWindow, statuses?: Record<string, ClaudeStatus>) => {
   if (!statuses) return undefined;
   for (const [fullPath, status] of Object.entries(statuses)) {
-    const projectName = fullPath.split('/').pop();
-    if (projectName === tabName) return status;
+    if (projectPathMatchesWindow(fullPath, tab)) return status;
   }
   return undefined;
 };
@@ -132,7 +130,7 @@ function TabBar(props: TabBarProps) {
     if (colorPickerTarget !== null) {
       const tab = tabs[colorPickerTarget];
       if (tab) {
-        onColorChange?.(tab.name, colorId);
+        onColorChange?.(windowKey(tab), colorId);
       }
     }
     setColorPickerTarget(null);
@@ -267,8 +265,7 @@ function TabBar(props: TabBarProps) {
     const ungrouped: { tab: EditorWindow; originalIndex: number }[] = [];
 
     tabs.forEach((tab, index) => {
-      const wKey = windowKey(tab);
-      const groupId = groupAssignments[wKey];
+      const groupId = getWindowScopedValue(groupAssignments, tab, legacyWindowKey(tab));
       if (groupId && groupIds.has(groupId)) {
         if (!grouped.has(groupId)) {
           grouped.set(groupId, []);
@@ -334,8 +331,8 @@ function TabBar(props: TabBarProps) {
       onDragOver={handleDragOver}
       onDrop={handleDrop}
       index={originalIndex}
-      claudeStatus={getClaudeStatusForTab(tab.name, claudeStatuses)}
-      colorId={tabColors?.[tab.name] ?? null}
+      claudeStatus={getClaudeStatusForTab(tab, claudeStatuses)}
+      colorId={tabColors ? getWindowScopedValue(tabColors, tab, tab.name) ?? null : null}
       onContextMenu={handleTabContextMenu}
       branch={showBranch !== false ? tab.branch : undefined}
     />
@@ -445,7 +442,11 @@ function TabBar(props: TabBarProps) {
 
       {colorPickerTarget !== null && (
         <ColorPicker
-          currentColorId={tabColors?.[tabs[colorPickerTarget]?.name] ?? null}
+          currentColorId={
+            tabColors && tabs[colorPickerTarget]
+              ? getWindowScopedValue(tabColors, tabs[colorPickerTarget], tabs[colorPickerTarget].name) ?? null
+              : null
+          }
           onSelect={handleColorSelect}
           onClose={handleColorPickerClose}
           anchorLeft={colorPickerAnchorLeft}
@@ -546,7 +547,11 @@ function TabBar(props: TabBarProps) {
                       {t("group.createNew")}
                     </button>
                   )}
-                  {tabContextMenu && tabs[tabContextMenu.index] && groupAssignments[windowKey(tabs[tabContextMenu.index])] && (
+                  {tabContextMenu && tabs[tabContextMenu.index] && getWindowScopedValue(
+                    groupAssignments,
+                    tabs[tabContextMenu.index],
+                    legacyWindowKey(tabs[tabContextMenu.index]),
+                  ) && (
                     <>
                       <div style={styles.contextMenuSeparator} />
                       <button

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -5,7 +5,7 @@ import WorktreeTab from "./WorktreeTab";
 import ColorPicker from "./ColorPicker";
 import AddTabMenu from "./AddTabMenu";
 import type { EditorWindow, ClaudeStatus, HistoryEntry, GroupDefinition, GroupAssignment, TabColorMap } from "../types/editor";
-import { getWindowScopedValue, legacyWindowKey, projectPathMatchesWindow, windowKey } from "../utils/store";
+import { getWindowScopedValue, legacyWindowKey, projectPathMatchesWindow, repositoryColorKey, windowKey } from "../utils/store";
 import { getColorById } from "../constants/tabColors";
 import { getInheritedRepositoryGroupId, groupRepositoryTabs, type TabEntry } from "../utils/repositoryTabs";
 
@@ -62,13 +62,13 @@ function TabBar(props: TabBarProps) {
   const { tabs, activeIndex, onTabClick, onNewTab, onCloseTab, onReorder, onReorderByVisual, claudeStatuses, tabColors, onColorChange, showBranch, history, showAddMenu, onAddMenuOpen, onAddMenuClose, onHistorySelect, onHistoryClear, onColorPickerOpen, onColorPickerClose, groups, groupAssignments, collapsedGroups, onAddGroup, onUpdateGroup, onDeleteGroup, onAssignTabsToGroup, onUnassignTabsFromGroup, onToggleGroupCollapse, onReorderGroups, groupColors, onSetGroupColor, onTabContextMenuOpen, onTabContextMenuClose, onWorktreeMenuOpen, onWorktreeMenuClose } = props;
   const { t } = useTranslation();
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
-  const [colorPickerTarget, setColorPickerTarget] = useState<number | null>(null);
+  const [colorPickerTarget, setColorPickerTarget] = useState<{ key: string; currentColorId: string | null } | null>(null);
   const [colorPickerAnchorLeft, setColorPickerAnchorLeft] = useState<number>(0);
   const [groupLabelMenu, setGroupLabelMenu] = useState<{ groupId: string; x: number; y: number } | null>(null);
   const [editingGroupId, setEditingGroupId] = useState<string | null>(null);
   const [editingGroupName, setEditingGroupName] = useState("");
   const [draggedGroupIndex, setDraggedGroupIndex] = useState<number | null>(null);
-  const [tabContextMenu, setTabContextMenu] = useState<{ index: number; indices: number[]; x: number; y: number; rect: DOMRect } | null>(null);
+  const [tabContextMenu, setTabContextMenu] = useState<{ index: number; indices: number[]; repositoryId?: string; x: number; y: number; rect: DOMRect } | null>(null);
   const [groupSubmenuOpen, setGroupSubmenuOpen] = useState(false);
   const [newGroupInput, setNewGroupInput] = useState<string | null>(null);
   const [groupColorPickerTarget, setGroupColorPickerTarget] = useState<string | null>(null);
@@ -123,6 +123,7 @@ function TabBar(props: TabBarProps) {
   }, [onTabContextMenuOpen]);
 
   const handleWorktreeContextMenu = useCallback(async (
+    repositoryId: string,
     indices: number[],
     preferredIndex: number,
     rect: DOMRect,
@@ -131,6 +132,7 @@ function TabBar(props: TabBarProps) {
     setTabContextMenu({
       index: preferredIndex,
       indices,
+      repositoryId,
       x: rect.left,
       y: rect.bottom,
       rect,
@@ -139,29 +141,35 @@ function TabBar(props: TabBarProps) {
 
   const handleOpenColorPicker = useCallback(async () => {
     if (tabContextMenu && containerRef.current) {
+      const tab = tabs[tabContextMenu.index];
+      if (!tab) return;
       const containerRect = containerRef.current.getBoundingClientRect();
       const rect = tabContextMenu.rect;
       setColorPickerAnchorLeft(rect.left - containerRect.left + rect.width / 2);
-      const idx = tabContextMenu.index;
+      const key = tabContextMenu.repositoryId
+        ? repositoryColorKey(tabContextMenu.repositoryId)
+        : windowKey(tab);
+      const currentColorId = tabContextMenu.repositoryId
+        ? tabColors?.[key] ?? null
+        : tabColors
+          ? getWindowScopedValue(tabColors, tab, tab.name) ?? null
+          : null;
       // Clear context menu state without resizing window (ColorPicker will resize)
       setTabContextMenu(null);
       setGroupSubmenuOpen(false);
       setNewGroupInput(null);
       await onColorPickerOpen();
-      setColorPickerTarget(idx);
+      setColorPickerTarget({ key, currentColorId });
     }
-  }, [tabContextMenu, onColorPickerOpen]);
+  }, [tabContextMenu, tabs, tabColors, onColorPickerOpen]);
 
   const handleColorSelect = useCallback((colorId: string | null) => {
-    if (colorPickerTarget !== null) {
-      const tab = tabs[colorPickerTarget];
-      if (tab) {
-        onColorChange?.(windowKey(tab), colorId);
-      }
+    if (colorPickerTarget) {
+      onColorChange?.(colorPickerTarget.key, colorId);
     }
     setColorPickerTarget(null);
     onColorPickerClose();
-  }, [colorPickerTarget, tabs, onColorChange, onColorPickerClose]);
+  }, [colorPickerTarget, onColorChange, onColorPickerClose]);
 
   const handleColorPickerClose = useCallback(() => {
     setColorPickerTarget(null);
@@ -389,11 +397,14 @@ function TabBar(props: TabBarProps) {
         entries={item.entries}
         activeIndex={activeIndex}
         statuses={statuses}
+        colorId={tabColors?.[repositoryColorKey(item.key)] ?? null}
         onTabClick={handleTabClick}
         onCloseTab={handleCloseTab}
         onMenuOpen={onWorktreeMenuOpen}
         onMenuClose={onWorktreeMenuClose}
-        onContextMenu={handleWorktreeContextMenu}
+        onContextMenu={(indices, preferredIndex, rect) =>
+          handleWorktreeContextMenu(item.key, indices, preferredIndex, rect)
+        }
       />
     );
   });
@@ -500,13 +511,9 @@ function TabBar(props: TabBarProps) {
         </button>
       </div>
 
-      {colorPickerTarget !== null && (
+      {colorPickerTarget && (
         <ColorPicker
-          currentColorId={
-            tabColors && tabs[colorPickerTarget]
-              ? getWindowScopedValue(tabColors, tabs[colorPickerTarget], tabs[colorPickerTarget].name) ?? null
-              : null
-          }
+          currentColorId={colorPickerTarget.currentColorId}
           onSelect={handleColorSelect}
           onClose={handleColorPickerClose}
           anchorLeft={colorPickerAnchorLeft}

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -76,6 +76,13 @@ function TabBar(props: TabBarProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const tabsWrapperRef = useRef<HTMLDivElement>(null);
   const addButtonRef = useRef<HTMLButtonElement>(null);
+  const contextMenuWindowKeys = useMemo(() => {
+    if (!tabContextMenu) return [];
+    return tabContextMenu.indices
+      .map((index) => tabs[index])
+      .filter((tab): tab is EditorWindow => Boolean(tab))
+      .map(windowKey);
+  }, [tabContextMenu, tabs]);
 
   useEffect(() => {
     if (activeIndex < 0) return;
@@ -169,39 +176,27 @@ function TabBar(props: TabBarProps) {
   }, [onTabContextMenuClose]);
 
   const handleAssignToGroup = useCallback((groupId: string) => {
-    if (tabContextMenu) {
-      const keys = tabContextMenu.indices
-        .map((index) => tabs[index])
-        .filter((tab): tab is EditorWindow => Boolean(tab))
-        .map(windowKey);
-      onAssignTabsToGroup(keys, groupId);
+    if (contextMenuWindowKeys.length > 0) {
+      onAssignTabsToGroup(contextMenuWindowKeys, groupId);
     }
     closeTabContextMenu();
-  }, [tabContextMenu, tabs, onAssignTabsToGroup, closeTabContextMenu]);
+  }, [contextMenuWindowKeys, onAssignTabsToGroup, closeTabContextMenu]);
 
   const handleUnassignFromGroup = useCallback(() => {
-    if (tabContextMenu) {
-      const keys = tabContextMenu.indices
-        .map((index) => tabs[index])
-        .filter((tab): tab is EditorWindow => Boolean(tab))
-        .map(windowKey);
-      onUnassignTabsFromGroup(keys);
+    if (contextMenuWindowKeys.length > 0) {
+      onUnassignTabsFromGroup(contextMenuWindowKeys);
     }
     closeTabContextMenu();
-  }, [tabContextMenu, tabs, onUnassignTabsFromGroup, closeTabContextMenu]);
+  }, [contextMenuWindowKeys, onUnassignTabsFromGroup, closeTabContextMenu]);
 
   const handleCreateNewGroup = useCallback(() => {
-    if (newGroupInput !== null && newGroupInput.trim() && tabContextMenu) {
+    if (newGroupInput !== null && newGroupInput.trim() && contextMenuWindowKeys.length > 0) {
       const groupId = onAddGroup(newGroupInput.trim());
-      const keys = tabContextMenu.indices
-        .map((index) => tabs[index])
-        .filter((tab): tab is EditorWindow => Boolean(tab))
-        .map(windowKey);
-      onAssignTabsToGroup(keys, groupId);
+      onAssignTabsToGroup(contextMenuWindowKeys, groupId);
     }
     setNewGroupInput(null);
     closeTabContextMenu();
-  }, [newGroupInput, onAddGroup, tabContextMenu, tabs, onAssignTabsToGroup, closeTabContextMenu]);
+  }, [newGroupInput, contextMenuWindowKeys, onAddGroup, onAssignTabsToGroup, closeTabContextMenu]);
 
   // Group label context menu
   const handleGroupLabelContextMenu = useCallback(async (e: React.MouseEvent, groupId: string) => {

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,11 +1,13 @@
 import { useState, useCallback, useRef, useMemo, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import Tab from "./Tab";
+import WorktreeTab from "./WorktreeTab";
 import ColorPicker from "./ColorPicker";
 import AddTabMenu from "./AddTabMenu";
 import type { EditorWindow, ClaudeStatus, HistoryEntry, GroupDefinition, GroupAssignment, TabColorMap } from "../types/editor";
 import { getWindowScopedValue, legacyWindowKey, projectPathMatchesWindow, windowKey } from "../utils/store";
 import { getColorById } from "../constants/tabColors";
+import { groupRepositoryTabs, type TabEntry } from "../utils/repositoryTabs";
 
 interface TabBarProps {
   tabs: EditorWindow[];
@@ -41,6 +43,8 @@ interface TabBarProps {
   onSetGroupColor: (groupId: string, colorId: string | null) => void;
   onTabContextMenuOpen: () => Promise<void>;
   onTabContextMenuClose: () => Promise<void>;
+  onWorktreeMenuOpen: (rowCount: number) => Promise<void>;
+  onWorktreeMenuClose: () => Promise<void>;
 }
 
 const toRgba = (rgb: { r: number; g: number; b: number }, alpha: number) =>
@@ -55,7 +59,7 @@ const getClaudeStatusForTab = (tab: EditorWindow, statuses?: Record<string, Clau
 };
 
 function TabBar(props: TabBarProps) {
-  const { tabs, activeIndex, onTabClick, onNewTab, onCloseTab, onReorder, onReorderByVisual, claudeStatuses, tabColors, onColorChange, showBranch, history, showAddMenu, onAddMenuOpen, onAddMenuClose, onHistorySelect, onHistoryClear, onColorPickerOpen, onColorPickerClose, groups, groupAssignments, collapsedGroups, onAddGroup, onUpdateGroup, onDeleteGroup, onAssignTabToGroup, onUnassignTabFromGroup, onToggleGroupCollapse, onReorderGroups, groupColors, onSetGroupColor, onTabContextMenuOpen, onTabContextMenuClose } = props;
+  const { tabs, activeIndex, onTabClick, onNewTab, onCloseTab, onReorder, onReorderByVisual, claudeStatuses, tabColors, onColorChange, showBranch, history, showAddMenu, onAddMenuOpen, onAddMenuClose, onHistorySelect, onHistoryClear, onColorPickerOpen, onColorPickerClose, groups, groupAssignments, collapsedGroups, onAddGroup, onUpdateGroup, onDeleteGroup, onAssignTabToGroup, onUnassignTabFromGroup, onToggleGroupCollapse, onReorderGroups, groupColors, onSetGroupColor, onTabContextMenuOpen, onTabContextMenuClose, onWorktreeMenuOpen, onWorktreeMenuClose } = props;
   const { t } = useTranslation();
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
   const [colorPickerTarget, setColorPickerTarget] = useState<number | null>(null);
@@ -338,6 +342,33 @@ function TabBar(props: TabBarProps) {
     />
   );
 
+  const renderRepositoryTabs = (entries: TabEntry[]) => groupRepositoryTabs(entries).map((item) => {
+    if (item.type === "tab") {
+      return renderTab(item.entry.tab, item.entry.originalIndex);
+    }
+
+    const statuses = new Map(
+      item.entries.map(({ tab, originalIndex }) => [
+        originalIndex,
+        getClaudeStatusForTab(tab, claudeStatuses),
+      ]),
+    );
+    return (
+      <WorktreeTab
+        key={item.key}
+        name={item.name}
+        entries={item.entries}
+        activeIndex={activeIndex}
+        statuses={statuses}
+        onTabClick={handleTabClick}
+        onCloseTab={handleCloseTab}
+        onMenuOpen={onWorktreeMenuOpen}
+        onMenuClose={onWorktreeMenuClose}
+        onContextMenu={handleTabContextMenu}
+      />
+    );
+  });
+
   return (
     <div ref={containerRef} style={styles.container}>
       {/* ドラッグ領域を最背面に配置（全体をカバー） */}
@@ -421,13 +452,13 @@ function TabBar(props: TabBarProps) {
               )}
 
               {/* Group tabs (hidden when collapsed) */}
-              {!isCollapsed && groupTabs.map(({ tab, originalIndex }) => renderTab(tab, originalIndex))}
+              {!isCollapsed && renderRepositoryTabs(groupTabs)}
             </div>
           );
         })}
 
         {/* Ungrouped tabs */}
-        {ungroupedTabs.map(({ tab, originalIndex }) => renderTab(tab, originalIndex))}
+        {renderRepositoryTabs(ungroupedTabs)}
 
         <button
           ref={addButtonRef}

--- a/src/components/WorktreeTab.test.tsx
+++ b/src/components/WorktreeTab.test.tsx
@@ -18,7 +18,7 @@ function makeEntry(index: number, branch: string, overrides: Partial<EditorWindo
   return { tab, originalIndex: index };
 }
 
-function setup() {
+function setup(colorId: string | null = null) {
   const props = {
     name: "project",
     entries: [
@@ -30,13 +30,19 @@ function setup() {
     ],
     activeIndex: 5,
     statuses: new Map([[2, "waiting" as const], [5, "generating" as const]]),
+    colorId,
     onTabClick: vi.fn(),
     onCloseTab: vi.fn(),
     onMenuOpen: vi.fn().mockResolvedValue(undefined),
     onMenuClose: vi.fn().mockResolvedValue(undefined),
     onContextMenu: vi.fn(),
   };
-  const view = render(<WorktreeTab {...props} />);
+  const view = render(
+    <>
+      <WorktreeTab {...props} />
+      <button type="button" onMouseDown={(event) => event.stopPropagation()}>other tab</button>
+    </>,
+  );
   const trigger = screen.getByRole("button", { name: "worktree.openBranches" });
   return { ...view, props, trigger, root: trigger.parentElement as HTMLElement };
 }
@@ -120,5 +126,23 @@ describe("WorktreeTab", () => {
     fireEvent.mouseDown(document.body);
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
     expect(props.onMenuClose).toHaveBeenCalledOnce();
+  });
+
+  it("closes before another tab stops mouse down propagation", () => {
+    const { props, trigger } = setup();
+    fireEvent.mouseDown(trigger, { button: 0 });
+
+    fireEvent.mouseDown(screen.getByRole("button", { name: "other tab" }), { button: 0 });
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(props.onMenuClose).toHaveBeenCalledOnce();
+
+    fireEvent.mouseDown(trigger, { button: 0 });
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+
+  it("applies the repository color to the aggregate tab", () => {
+    const { trigger } = setup("red");
+
+    expect(trigger).toHaveStyle({ background: "rgb(110, 81, 83)" });
   });
 });

--- a/src/components/WorktreeTab.test.tsx
+++ b/src/components/WorktreeTab.test.tsx
@@ -1,0 +1,88 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import type { EditorWindow } from "../types/editor";
+import type { TabEntry } from "../utils/repositoryTabs";
+import WorktreeTab from "./WorktreeTab";
+
+function makeEntry(index: number, branch: string): TabEntry {
+  const tab: EditorWindow = {
+    id: index + 1,
+    name: "project",
+    path: `/worktrees/${branch}`,
+    branch,
+    repository_id: "/projects/project/.git",
+    repository_name: "project",
+    bundle_id: "com.microsoft.VSCode",
+    editor_name: "VSCode",
+  };
+  return { tab, originalIndex: index };
+}
+
+function setup() {
+  const props = {
+    name: "project",
+    entries: [makeEntry(2, "main"), makeEntry(5, "feature/search")],
+    activeIndex: 5,
+    statuses: new Map([[2, "waiting" as const], [5, "generating" as const]]),
+    onTabClick: vi.fn(),
+    onCloseTab: vi.fn(),
+    onMenuOpen: vi.fn().mockResolvedValue(undefined),
+    onMenuClose: vi.fn().mockResolvedValue(undefined),
+  };
+  const view = render(<WorktreeTab {...props} />);
+  const trigger = screen.getByRole("button", { name: "worktree.openBranches" });
+  return { ...view, props, trigger, root: trigger.parentElement as HTMLElement };
+}
+
+describe("WorktreeTab", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows branch rows on hover and expands for their count", () => {
+    const { props, root } = setup();
+
+    fireEvent.mouseEnter(root);
+
+    expect(screen.getByRole("menu", { name: "worktree.branchList" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /main/ })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /feature\/search/ })).toBeInTheDocument();
+    expect(props.onMenuOpen).toHaveBeenCalledWith(2);
+  });
+
+  it("switches to the selected editor window", () => {
+    const { props, root } = setup();
+    fireEvent.mouseEnter(root);
+
+    fireEvent.click(screen.getByRole("menuitem", { name: /main/ }));
+
+    expect(props.onTabClick).toHaveBeenCalledWith(2);
+    expect(props.onMenuClose).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the list open after click pins it", () => {
+    vi.useFakeTimers();
+    const { props, root, trigger } = setup();
+    fireEvent.mouseEnter(root);
+    fireEvent.click(trigger);
+
+    fireEvent.mouseLeave(root);
+    act(() => vi.advanceTimersByTime(250));
+
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(props.onMenuClose).not.toHaveBeenCalled();
+  });
+
+  it("closes an unpinned hover list after the delay", () => {
+    vi.useFakeTimers();
+    const { props, root } = setup();
+    fireEvent.mouseEnter(root);
+
+    fireEvent.mouseLeave(root);
+    act(() => vi.advanceTimersByTime(199));
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(props.onMenuClose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/WorktreeTab.test.tsx
+++ b/src/components/WorktreeTab.test.tsx
@@ -1,9 +1,9 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type { EditorWindow } from "../types/editor";
 import type { TabEntry } from "../utils/repositoryTabs";
 import WorktreeTab from "./WorktreeTab";
 
-function makeEntry(index: number, branch: string): TabEntry {
+function makeEntry(index: number, branch: string, overrides: Partial<EditorWindow> = {}): TabEntry {
   const tab: EditorWindow = {
     id: index + 1,
     name: "project",
@@ -13,6 +13,7 @@ function makeEntry(index: number, branch: string): TabEntry {
     repository_name: "project",
     bundle_id: "com.microsoft.VSCode",
     editor_name: "VSCode",
+    ...overrides,
   };
   return { tab, originalIndex: index };
 }
@@ -20,13 +21,20 @@ function makeEntry(index: number, branch: string): TabEntry {
 function setup() {
   const props = {
     name: "project",
-    entries: [makeEntry(2, "main"), makeEntry(5, "feature/search")],
+    entries: [
+      makeEntry(2, "main"),
+      makeEntry(5, "feature/search", {
+        bundle_id: "com.todesktop.230313mzl4w4u92",
+        editor_name: "Cursor",
+      }),
+    ],
     activeIndex: 5,
     statuses: new Map([[2, "waiting" as const], [5, "generating" as const]]),
     onTabClick: vi.fn(),
     onCloseTab: vi.fn(),
     onMenuOpen: vi.fn().mockResolvedValue(undefined),
     onMenuClose: vi.fn().mockResolvedValue(undefined),
+    onContextMenu: vi.fn(),
   };
   const view = render(<WorktreeTab {...props} />);
   const trigger = screen.getByRole("button", { name: "worktree.openBranches" });
@@ -34,24 +42,34 @@ function setup() {
 }
 
 describe("WorktreeTab", () => {
-  afterEach(() => {
-    vi.useRealTimers();
-  });
+  it("shows branch rows on click and expands for their count", () => {
+    const { props, trigger } = setup();
 
-  it("shows branch rows on hover and expands for their count", () => {
-    const { props, root } = setup();
-
-    fireEvent.mouseEnter(root);
+    fireEvent.click(trigger);
 
     expect(screen.getByRole("menu", { name: "worktree.branchList" })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: /main/ })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: /feature\/search/ })).toBeInTheDocument();
+    expect(screen.getByText("VSCode")).toBeInTheDocument();
+    expect(screen.getByText("Cursor")).toBeInTheDocument();
     expect(props.onMenuOpen).toHaveBeenCalledWith(2);
   });
 
+  it("opens the parent context menu for every repository window", () => {
+    const { props, trigger } = setup();
+
+    fireEvent.contextMenu(trigger);
+
+    expect(props.onContextMenu).toHaveBeenCalledWith(
+      [2, 5],
+      5,
+      expect.objectContaining({ left: 0, bottom: 0 }),
+    );
+  });
+
   it("switches to the selected editor window", () => {
-    const { props, root } = setup();
-    fireEvent.mouseEnter(root);
+    const { props, trigger } = setup();
+    fireEvent.click(trigger);
 
     fireEvent.click(screen.getByRole("menuitem", { name: /main/ }));
 
@@ -59,29 +77,30 @@ describe("WorktreeTab", () => {
     expect(props.onMenuClose).toHaveBeenCalledOnce();
   });
 
-  it("keeps the list open after click pins it", () => {
-    vi.useFakeTimers();
-    const { props, root, trigger } = setup();
-    fireEvent.mouseEnter(root);
+  it("toggles the list with repeated clicks", () => {
+    const { props, trigger } = setup();
+    fireEvent.click(trigger);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
     fireEvent.click(trigger);
 
-    fireEvent.mouseLeave(root);
-    act(() => vi.advanceTimersByTime(250));
-
-    expect(screen.getByRole("menu")).toBeInTheDocument();
-    expect(props.onMenuClose).not.toHaveBeenCalled();
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(props.onMenuClose).toHaveBeenCalledOnce();
   });
 
-  it("closes an unpinned hover list after the delay", () => {
-    vi.useFakeTimers();
-    const { props, root } = setup();
+  it("does not open the list on hover", () => {
+    const { root } = setup();
+
     fireEvent.mouseEnter(root);
 
-    fireEvent.mouseLeave(root);
-    act(() => vi.advanceTimersByTime(199));
-    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
 
-    act(() => vi.advanceTimersByTime(1));
+  it("closes the list when clicking outside", () => {
+    const { props, trigger } = setup();
+    fireEvent.click(trigger);
+
+    fireEvent.mouseDown(document.body);
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
     expect(props.onMenuClose).toHaveBeenCalledOnce();
   });

--- a/src/components/WorktreeTab.test.tsx
+++ b/src/components/WorktreeTab.test.tsx
@@ -55,6 +55,23 @@ describe("WorktreeTab", () => {
     expect(props.onMenuOpen).toHaveBeenCalledWith(2);
   });
 
+  it("opens on primary mouse down without toggling again on click", () => {
+    const { props, trigger } = setup();
+
+    fireEvent.mouseDown(trigger, { button: 0 });
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    fireEvent.click(trigger, { detail: 1 });
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(props.onMenuOpen).toHaveBeenCalledOnce();
+    expect(props.onMenuClose).not.toHaveBeenCalled();
+
+    fireEvent.mouseDown(trigger, { button: 0 });
+    fireEvent.click(trigger, { detail: 1 });
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(props.onMenuClose).toHaveBeenCalledOnce();
+  });
+
   it("opens the parent context menu for every repository window", () => {
     const { props, trigger } = setup();
 

--- a/src/components/WorktreeTab.tsx
+++ b/src/components/WorktreeTab.tsx
@@ -79,7 +79,7 @@ function WorktreeTab({
     };
     document.addEventListener("mousedown", handlePointerDown);
     return () => document.removeEventListener("mousedown", handlePointerDown);
-  }, [closeMenu, contextEntry.tab.bundle_id, contextEntry.tab.repository_id, isOpen]);
+  }, [closeMenu, isOpen]);
 
   return (
     <div
@@ -97,7 +97,7 @@ function WorktreeTab({
         type="button"
         style={{
           ...styles.tab,
-          ...(isOpen && !isActive ? styles.tabHover : {}),
+          ...(isOpen && !isActive ? styles.tabOpen : {}),
           ...(isActive ? styles.tabActive : {}),
         }}
         onClick={() => {
@@ -133,7 +133,6 @@ function WorktreeTab({
           ref={menuRef}
           role="menu"
           aria-label={t("worktree.branchList", { name })}
-          data-worktree-menu={`${contextEntry.tab.bundle_id}:${contextEntry.tab.repository_id}`}
           style={{ ...styles.menu, left: menuPosition.left, top: menuPosition.top }}
         >
           {entries.map(({ tab, originalIndex }) => {
@@ -215,7 +214,7 @@ const styles: Record<string, React.CSSProperties> = {
     background: "#484848",
     borderBottom: "2px solid #007aff",
   },
-  tabHover: {
+  tabOpen: {
     background: "#333333",
   },
   name: {
@@ -240,6 +239,7 @@ const styles: Record<string, React.CSSProperties> = {
     color: "rgba(255, 255, 255, 0.75)",
     fontSize: "10px",
     fontWeight: 600,
+    fontVariantNumeric: "tabular-nums",
   },
   chevron: {
     color: "rgba(255, 255, 255, 0.55)",

--- a/src/components/WorktreeTab.tsx
+++ b/src/components/WorktreeTab.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
+import { getColorById } from "../constants/tabColors";
 import { EDITOR_DISPLAY_NAMES, type ClaudeStatus } from "../types/editor";
 import type { TabEntry } from "../utils/repositoryTabs";
 
@@ -9,6 +10,7 @@ interface WorktreeTabProps {
   entries: TabEntry[];
   activeIndex: number;
   statuses: Map<number, ClaudeStatus | undefined>;
+  colorId?: string | null;
   onTabClick: (index: number) => void;
   onCloseTab: (index: number) => void;
   onMenuOpen: (rowCount: number) => Promise<void>;
@@ -17,12 +19,15 @@ interface WorktreeTabProps {
 }
 
 const MENU_WIDTH = 280;
+const blend = (base: number, color: number, ratio: number) =>
+  Math.round(base * (1 - ratio) + color * ratio);
 
 function WorktreeTab({
   name,
   entries,
   activeIndex,
   statuses,
+  colorId,
   onTabClick,
   onCloseTab,
   onMenuOpen,
@@ -42,6 +47,14 @@ function WorktreeTab({
   const showEditorNames = new Set(entries.map((entry) => entry.tab.bundle_id)).size > 1;
   const hasWaiting = entries.some((entry) => statuses.get(entry.originalIndex) === "waiting");
   const hasGenerating = entries.some((entry) => statuses.get(entry.originalIndex) === "generating");
+  const colorStyle: React.CSSProperties = {};
+  const tabColor = getColorById(colorId);
+  if (tabColor) {
+    const { r, g, b } = tabColor.rgb;
+    const base = isActive ? 72 : isOpen ? 51 : 37;
+    const ratio = isActive ? 0.25 : isOpen ? 0.2 : 0.15;
+    colorStyle.background = `rgb(${blend(base, r, ratio)}, ${blend(base, g, ratio)}, ${blend(base, b, ratio)})`;
+  }
 
   const closeMenu = useCallback(() => {
     if (!isOpen) return;
@@ -85,8 +98,8 @@ function WorktreeTab({
       if (menuRef.current?.contains(target)) return;
       closeMenu();
     };
-    document.addEventListener("mousedown", handlePointerDown);
-    return () => document.removeEventListener("mousedown", handlePointerDown);
+    document.addEventListener("mousedown", handlePointerDown, true);
+    return () => document.removeEventListener("mousedown", handlePointerDown, true);
   }, [closeMenu, isOpen]);
 
   return (
@@ -107,6 +120,7 @@ function WorktreeTab({
           ...styles.tab,
           ...(isOpen && !isActive ? styles.tabOpen : {}),
           ...(isActive ? styles.tabActive : {}),
+          ...colorStyle,
         }}
         onMouseDown={(event) => {
           if (event.button !== 0) return;

--- a/src/components/WorktreeTab.tsx
+++ b/src/components/WorktreeTab.tsx
@@ -1,0 +1,340 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+import type { ClaudeStatus } from "../types/editor";
+import type { TabEntry } from "../utils/repositoryTabs";
+
+interface WorktreeTabProps {
+  name: string;
+  entries: TabEntry[];
+  activeIndex: number;
+  statuses: Map<number, ClaudeStatus | undefined>;
+  onTabClick: (index: number) => void;
+  onCloseTab: (index: number) => void;
+  onMenuOpen: (rowCount: number) => Promise<void>;
+  onMenuClose: () => Promise<void>;
+  onContextMenu?: (index: number, rect: DOMRect) => void;
+}
+
+const CLOSE_DELAY_MS = 200;
+const MENU_WIDTH = 240;
+
+function WorktreeTab({
+  name,
+  entries,
+  activeIndex,
+  statuses,
+  onTabClick,
+  onCloseTab,
+  onMenuOpen,
+  onMenuClose,
+  onContextMenu,
+}: WorktreeTabProps) {
+  const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+  const [isPinned, setIsPinned] = useState(false);
+  const [menuPosition, setMenuPosition] = useState({ left: 8, top: 36 });
+  const rootRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const isOpenRef = useRef(false);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const activeEntry = entries.find((entry) => entry.originalIndex === activeIndex);
+  const contextEntry = activeEntry ?? entries[0];
+  const isActive = Boolean(activeEntry);
+  const hasWaiting = entries.some((entry) => statuses.get(entry.originalIndex) === "waiting");
+  const hasGenerating = entries.some((entry) => statuses.get(entry.originalIndex) === "generating");
+
+  const cancelClose = useCallback(() => {
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+
+  const closeMenu = useCallback(() => {
+    cancelClose();
+    if (!isOpen) return;
+    setIsOpen(false);
+    setIsPinned(false);
+    void onMenuClose();
+  }, [cancelClose, isOpen, onMenuClose]);
+
+  const openMenu = useCallback(() => {
+    cancelClose();
+    const rect = rootRef.current?.getBoundingClientRect();
+    if (rect) {
+      const maxLeft = Math.max(8, window.innerWidth - MENU_WIDTH - 8);
+      setMenuPosition({ left: Math.min(Math.max(8, rect.left), maxLeft), top: rect.bottom });
+    }
+    if (!isOpen) {
+      setIsOpen(true);
+      void onMenuOpen(entries.length);
+    }
+  }, [cancelClose, entries.length, isOpen, onMenuOpen]);
+
+  const scheduleClose = useCallback(() => {
+    cancelClose();
+    if (isPinned) return;
+    closeTimerRef.current = setTimeout(closeMenu, CLOSE_DELAY_MS);
+  }, [cancelClose, closeMenu, isPinned]);
+
+  useEffect(() => {
+    isOpenRef.current = isOpen;
+  }, [isOpen]);
+
+  useEffect(() => () => {
+    cancelClose();
+    if (isOpenRef.current) void onMenuClose();
+  }, [cancelClose, onMenuClose]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (rootRef.current?.contains(target)) return;
+      if (menuRef.current?.contains(target)) return;
+      closeMenu();
+    };
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => document.removeEventListener("mousedown", handlePointerDown);
+  }, [closeMenu, contextEntry.tab.bundle_id, contextEntry.tab.repository_id, isOpen]);
+
+  return (
+    <div
+      ref={rootRef}
+      style={styles.root}
+      onMouseEnter={openMenu}
+      onMouseLeave={scheduleClose}
+      onKeyDown={(event) => {
+        if (event.key === "Escape" && isOpen) {
+          event.stopPropagation();
+          closeMenu();
+        }
+      }}
+      data-tab-index={isActive ? activeIndex : contextEntry.originalIndex}
+    >
+      <button
+        type="button"
+        style={{
+          ...styles.tab,
+          ...(isOpen && !isActive ? styles.tabHover : {}),
+          ...(isActive ? styles.tabActive : {}),
+        }}
+        onClick={() => {
+          if (isOpen && isPinned) {
+            closeMenu();
+            return;
+          }
+          setIsPinned(true);
+          openMenu();
+        }}
+        onContextMenu={(event) => {
+          event.preventDefault();
+          cancelClose();
+          setIsOpen(false);
+          setIsPinned(false);
+          onContextMenu?.(contextEntry.originalIndex, event.currentTarget.getBoundingClientRect());
+        }}
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        aria-label={t("worktree.openBranches", { name })}
+        title={t("worktree.openBranches", { name })}
+      >
+        <span style={styles.name}>{name}</span>
+        <span style={styles.count}>{entries.length}</span>
+        {hasGenerating && <span style={styles.badgeGenerating} className="pulse-animation" />}
+        {!hasGenerating && hasWaiting && <span style={styles.badgeWaiting} />}
+        <span aria-hidden="true" style={styles.chevron}>⌄</span>
+      </button>
+
+      {isOpen && createPortal(
+        <div
+          ref={menuRef}
+          role="menu"
+          aria-label={t("worktree.branchList", { name })}
+          data-worktree-menu={`${contextEntry.tab.bundle_id}:${contextEntry.tab.repository_id}`}
+          style={{ ...styles.menu, left: menuPosition.left, top: menuPosition.top }}
+          onMouseEnter={cancelClose}
+          onMouseLeave={scheduleClose}
+        >
+          {entries.map(({ tab, originalIndex }) => {
+            const status = statuses.get(originalIndex);
+            const branchName = tab.branch || tab.name || t("app.untitled");
+            const rowActive = originalIndex === activeIndex;
+            return (
+              <div key={`${tab.bundle_id}:${tab.id}`} style={styles.row}>
+                <button
+                  type="button"
+                  role="menuitem"
+                  aria-current={rowActive ? "page" : undefined}
+                  style={{ ...styles.branchButton, ...(rowActive ? styles.branchButtonActive : {}) }}
+                  onClick={() => {
+                    onTabClick(originalIndex);
+                    closeMenu();
+                  }}
+                >
+                  <span aria-hidden="true" style={styles.activeMarker}>{rowActive ? "●" : ""}</span>
+                  <span style={styles.branchName}>⑂ {branchName}</span>
+                  {status === "waiting" && <span style={styles.badgeWaiting} />}
+                  {status === "generating" && <span style={styles.badgeGenerating} className="pulse-animation" />}
+                </button>
+                <button
+                  type="button"
+                  style={styles.closeButton}
+                  onClick={() => {
+                    onCloseTab(originalIndex);
+                    if (entries.length === 2) closeMenu();
+                  }}
+                  aria-label={t("worktree.closeBranch", { branch: branchName })}
+                  title={t("tabBar.closeTooltip")}
+                >
+                  ×
+                </button>
+              </div>
+            );
+          })}
+        </div>,
+        document.body,
+      )}
+    </div>
+  );
+}
+
+const badgeStyle: React.CSSProperties = {
+  width: "8px",
+  height: "8px",
+  borderRadius: "50%",
+  flexShrink: 0,
+};
+
+const styles: Record<string, React.CSSProperties> = {
+  root: {
+    height: "32px",
+    flexShrink: 0,
+  },
+  tab: {
+    display: "flex",
+    alignItems: "center",
+    height: "32px",
+    minWidth: "110px",
+    maxWidth: "220px",
+    padding: "0 10px 0 12px",
+    gap: "7px",
+    border: "none",
+    borderBottom: "2px solid transparent",
+    borderRadius: "6px 6px 0 0",
+    background: "#252525",
+    color: "rgba(255, 255, 255, 0.9)",
+    cursor: "pointer",
+  },
+  tabActive: {
+    background: "#484848",
+    borderBottom: "2px solid #007aff",
+  },
+  tabHover: {
+    background: "#333333",
+  },
+  name: {
+    minWidth: 0,
+    flex: 1,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    textAlign: "left",
+    fontSize: "12px",
+    fontWeight: 500,
+  },
+  count: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    minWidth: "18px",
+    height: "18px",
+    padding: "0 5px",
+    borderRadius: "9px",
+    background: "rgba(255, 255, 255, 0.12)",
+    color: "rgba(255, 255, 255, 0.75)",
+    fontSize: "10px",
+    fontWeight: 600,
+  },
+  chevron: {
+    color: "rgba(255, 255, 255, 0.55)",
+    fontSize: "13px",
+  },
+  menu: {
+    position: "fixed",
+    width: `${MENU_WIDTH}px`,
+    padding: "4px",
+    border: "1px solid rgba(255, 255, 255, 0.15)",
+    borderRadius: "6px",
+    background: "#2d2d2d",
+    boxShadow: "0 4px 12px rgba(0, 0, 0, 0.5)",
+    zIndex: 1001,
+    maxHeight: "400px",
+    overflowY: "auto",
+  },
+  row: {
+    display: "flex",
+    alignItems: "center",
+    minHeight: "32px",
+    borderRadius: "4px",
+  },
+  branchButton: {
+    display: "flex",
+    alignItems: "center",
+    minWidth: 0,
+    flex: 1,
+    height: "32px",
+    padding: "0 8px",
+    gap: "7px",
+    border: "none",
+    borderRadius: "4px",
+    background: "transparent",
+    color: "rgba(255, 255, 255, 0.85)",
+    cursor: "pointer",
+    textAlign: "left",
+  },
+  branchButtonActive: {
+    background: "rgba(0, 122, 255, 0.18)",
+    color: "#fff",
+  },
+  activeMarker: {
+    width: "8px",
+    color: "#007aff",
+    fontSize: "8px",
+    flexShrink: 0,
+  },
+  branchName: {
+    minWidth: 0,
+    flex: 1,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    fontSize: "12px",
+  },
+  closeButton: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "28px",
+    height: "28px",
+    padding: 0,
+    border: "none",
+    borderRadius: "4px",
+    background: "transparent",
+    color: "rgba(255, 255, 255, 0.6)",
+    cursor: "pointer",
+    fontSize: "14px",
+  },
+  badgeWaiting: {
+    ...badgeStyle,
+    backgroundColor: "#007aff",
+  },
+  badgeGenerating: {
+    ...badgeStyle,
+    backgroundColor: "#ff3b30",
+  },
+};
+
+export default WorktreeTab;

--- a/src/components/WorktreeTab.tsx
+++ b/src/components/WorktreeTab.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
-import type { ClaudeStatus } from "../types/editor";
+import { EDITOR_DISPLAY_NAMES, type ClaudeStatus } from "../types/editor";
 import type { TabEntry } from "../utils/repositoryTabs";
 
 interface WorktreeTabProps {
@@ -13,11 +13,10 @@ interface WorktreeTabProps {
   onCloseTab: (index: number) => void;
   onMenuOpen: (rowCount: number) => Promise<void>;
   onMenuClose: () => Promise<void>;
-  onContextMenu?: (index: number, rect: DOMRect) => void;
+  onContextMenu?: (indices: number[], preferredIndex: number, rect: DOMRect) => void;
 }
 
-const CLOSE_DELAY_MS = 200;
-const MENU_WIDTH = 240;
+const MENU_WIDTH = 280;
 
 function WorktreeTab({
   name,
@@ -32,36 +31,25 @@ function WorktreeTab({
 }: WorktreeTabProps) {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
-  const [isPinned, setIsPinned] = useState(false);
   const [menuPosition, setMenuPosition] = useState({ left: 8, top: 36 });
   const rootRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const isOpenRef = useRef(false);
-  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const activeEntry = entries.find((entry) => entry.originalIndex === activeIndex);
   const contextEntry = activeEntry ?? entries[0];
   const isActive = Boolean(activeEntry);
+  const showEditorNames = new Set(entries.map((entry) => entry.tab.bundle_id)).size > 1;
   const hasWaiting = entries.some((entry) => statuses.get(entry.originalIndex) === "waiting");
   const hasGenerating = entries.some((entry) => statuses.get(entry.originalIndex) === "generating");
 
-  const cancelClose = useCallback(() => {
-    if (closeTimerRef.current) {
-      clearTimeout(closeTimerRef.current);
-      closeTimerRef.current = null;
-    }
-  }, []);
-
   const closeMenu = useCallback(() => {
-    cancelClose();
     if (!isOpen) return;
     setIsOpen(false);
-    setIsPinned(false);
     void onMenuClose();
-  }, [cancelClose, isOpen, onMenuClose]);
+  }, [isOpen, onMenuClose]);
 
   const openMenu = useCallback(() => {
-    cancelClose();
     const rect = rootRef.current?.getBoundingClientRect();
     if (rect) {
       const maxLeft = Math.max(8, window.innerWidth - MENU_WIDTH - 8);
@@ -71,22 +59,15 @@ function WorktreeTab({
       setIsOpen(true);
       void onMenuOpen(entries.length);
     }
-  }, [cancelClose, entries.length, isOpen, onMenuOpen]);
-
-  const scheduleClose = useCallback(() => {
-    cancelClose();
-    if (isPinned) return;
-    closeTimerRef.current = setTimeout(closeMenu, CLOSE_DELAY_MS);
-  }, [cancelClose, closeMenu, isPinned]);
+  }, [entries.length, isOpen, onMenuOpen]);
 
   useEffect(() => {
     isOpenRef.current = isOpen;
   }, [isOpen]);
 
   useEffect(() => () => {
-    cancelClose();
     if (isOpenRef.current) void onMenuClose();
-  }, [cancelClose, onMenuClose]);
+  }, [onMenuClose]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -104,8 +85,6 @@ function WorktreeTab({
     <div
       ref={rootRef}
       style={styles.root}
-      onMouseEnter={openMenu}
-      onMouseLeave={scheduleClose}
       onKeyDown={(event) => {
         if (event.key === "Escape" && isOpen) {
           event.stopPropagation();
@@ -122,19 +101,20 @@ function WorktreeTab({
           ...(isActive ? styles.tabActive : {}),
         }}
         onClick={() => {
-          if (isOpen && isPinned) {
+          if (isOpen) {
             closeMenu();
             return;
           }
-          setIsPinned(true);
           openMenu();
         }}
         onContextMenu={(event) => {
           event.preventDefault();
-          cancelClose();
           setIsOpen(false);
-          setIsPinned(false);
-          onContextMenu?.(contextEntry.originalIndex, event.currentTarget.getBoundingClientRect());
+          onContextMenu?.(
+            entries.map((entry) => entry.originalIndex),
+            contextEntry.originalIndex,
+            event.currentTarget.getBoundingClientRect(),
+          );
         }}
         aria-haspopup="menu"
         aria-expanded={isOpen}
@@ -155,8 +135,6 @@ function WorktreeTab({
           aria-label={t("worktree.branchList", { name })}
           data-worktree-menu={`${contextEntry.tab.bundle_id}:${contextEntry.tab.repository_id}`}
           style={{ ...styles.menu, left: menuPosition.left, top: menuPosition.top }}
-          onMouseEnter={cancelClose}
-          onMouseLeave={scheduleClose}
         >
           {entries.map(({ tab, originalIndex }) => {
             const status = statuses.get(originalIndex);
@@ -176,6 +154,11 @@ function WorktreeTab({
                 >
                   <span aria-hidden="true" style={styles.activeMarker}>{rowActive ? "●" : ""}</span>
                   <span style={styles.branchName}>⑂ {branchName}</span>
+                  {showEditorNames && (
+                    <span style={styles.editorName}>
+                      {EDITOR_DISPLAY_NAMES[tab.bundle_id] || tab.editor_name}
+                    </span>
+                  )}
                   {status === "waiting" && <span style={styles.badgeWaiting} />}
                   {status === "generating" && <span style={styles.badgeGenerating} className="pulse-animation" />}
                 </button>
@@ -312,6 +295,11 @@ const styles: Record<string, React.CSSProperties> = {
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
     fontSize: "12px",
+  },
+  editorName: {
+    flexShrink: 0,
+    color: "rgba(255, 255, 255, 0.5)",
+    fontSize: "10px",
   },
   closeButton: {
     display: "flex",

--- a/src/components/WorktreeTab.tsx
+++ b/src/components/WorktreeTab.tsx
@@ -61,6 +61,14 @@ function WorktreeTab({
     }
   }, [entries.length, isOpen, onMenuOpen]);
 
+  const toggleMenu = useCallback(() => {
+    if (isOpen) {
+      closeMenu();
+      return;
+    }
+    openMenu();
+  }, [closeMenu, isOpen, openMenu]);
+
   useEffect(() => {
     isOpenRef.current = isOpen;
   }, [isOpen]);
@@ -100,12 +108,14 @@ function WorktreeTab({
           ...(isOpen && !isActive ? styles.tabOpen : {}),
           ...(isActive ? styles.tabActive : {}),
         }}
-        onClick={() => {
-          if (isOpen) {
-            closeMenu();
-            return;
-          }
-          openMenu();
+        onMouseDown={(event) => {
+          if (event.button !== 0) return;
+          event.stopPropagation();
+          toggleMenu();
+        }}
+        onClick={(event) => {
+          // Mouse activation is handled on mousedown so it cannot be lost while the app activates.
+          if (event.detail === 0) toggleMenu();
         }}
         onContextMenu={(event) => {
           event.preventDefault();

--- a/src/hooks/useAppLifecycle.test.ts
+++ b/src/hooks/useAppLifecycle.test.ts
@@ -221,6 +221,22 @@ describe("useAppLifecycle", () => {
       expect(appWindow.setPosition).toHaveBeenCalled();
     });
 
+    it("expands the worktree menu to match its row count", async () => {
+      const appWindow = getCurrentWindow();
+      const { result } = setup({ "onboarding:completed": true });
+
+      await waitFor(() => {
+        expect(result.current.onboardingCompleted).toBe(true);
+      });
+      vi.mocked(appWindow.setSize).mockClear();
+
+      await act(async () => {
+        await result.current.handleWorktreeMenuOpen(3);
+      });
+
+      expect(appWindow.setSize).toHaveBeenLastCalledWith(new LogicalSize(1920, 140));
+    });
+
   });
 
   describe("app-activated event", () => {

--- a/src/hooks/useAppLifecycle.test.ts
+++ b/src/hooks/useAppLifecycle.test.ts
@@ -312,6 +312,41 @@ describe("useAppLifecycle", () => {
       });
     });
 
+    it("does not resize the window when the tab manager becomes active", async () => {
+      vi.mocked(invoke).mockResolvedValue(true);
+      const { result, listeners, params } = setup({ "onboarding:completed": true });
+
+      await waitFor(() => {
+        expect(result.current.hasAccessibilityPermission).toBe(true);
+        expect(result.current.onboardingCompleted).toBe(true);
+        expect(listeners.has("app-activated")).toBe(true);
+        expect(params.syncActiveTabRef.current).toHaveBeenCalled();
+      });
+
+      const appWindow = getCurrentWindow();
+      vi.mocked(appWindow.setMaxSize).mockClear();
+      vi.mocked(appWindow.setSize).mockClear();
+      vi.mocked(appWindow.setPosition).mockClear();
+
+      await act(async () => {
+        const handler = listeners.get("app-activated")!;
+        handler({
+          payload: {
+            app_type: "tab_manager",
+            bundle_id: null,
+            is_on_primary_screen: true,
+            covers_editor: false,
+          } satisfies AppActivationPayload,
+        });
+      });
+
+      expect(params.isEditorActiveRef.current).toBe(false);
+      expect(params.isTabManagerActiveRef.current).toBe(true);
+      expect(appWindow.setMaxSize).not.toHaveBeenCalled();
+      expect(appWindow.setSize).not.toHaveBeenCalled();
+      expect(appWindow.setPosition).not.toHaveBeenCalled();
+    });
+
     it("hides window on other app activation", async () => {
       vi.mocked(invoke).mockResolvedValue(true);
       const { result, listeners, params } = setup({ "onboarding:completed": true });

--- a/src/hooks/useAppLifecycle.ts
+++ b/src/hooks/useAppLifecycle.ts
@@ -33,6 +33,8 @@ interface UseAppLifecycleReturn {
   handleAddMenuClose: () => Promise<void>;
   handleTabContextMenuOpen: () => Promise<void>;
   handleTabContextMenuClose: () => Promise<void>;
+  handleWorktreeMenuOpen: (rowCount: number) => Promise<void>;
+  handleWorktreeMenuClose: () => Promise<void>;
 }
 
 function getMonitorKey(monitor: Awaited<ReturnType<typeof currentMonitor>>): string | null {
@@ -292,6 +294,10 @@ export function useAppLifecycle({
 
   const handleColorPickerOpen = useCallback(() => expandWindow(COLOR_PICKER_HEIGHT), [expandWindow]);
   const handleTabContextMenuOpen = useCallback(() => expandWindow(CONTEXT_MENU_HEIGHT), [expandWindow]);
+  const handleWorktreeMenuOpen = useCallback(
+    (rowCount: number) => expandWindow(Math.min(420, rowCount * 32 + 8)),
+    [expandWindow],
+  );
   const handleOverlayClose = useCallback(async () => { await resizeTabBar(); }, [resizeTabBar]);
 
   const handleAddMenuOpen = useCallback(async () => {
@@ -433,5 +439,7 @@ export function useAppLifecycle({
     handleAddMenuClose,
     handleTabContextMenuOpen,
     handleTabContextMenuClose: handleOverlayClose,
+    handleWorktreeMenuOpen,
+    handleWorktreeMenuClose: handleOverlayClose,
   };
 }

--- a/src/hooks/useAppLifecycle.ts
+++ b/src/hooks/useAppLifecycle.ts
@@ -344,11 +344,12 @@ export function useAppLifecycle({
           if (app_type === "editor" && bundle_id) {
             currentBundleIdRef.current = bundle_id;
           }
+          // Keep the current size when a click activates the tab manager so the click can finish.
           if (app_type === "editor") {
             // Wait 150ms for macOS window animation to complete
             await new Promise((resolve) => setTimeout(resolve, 150));
+            await resizeTabBar();
           }
-          await resizeTabBar();
           isVisibleRef.current = true;
           if (app_type === "editor") {
             await fetchWindowsRef.current();

--- a/src/hooks/useClaudeStatus.test.ts
+++ b/src/hooks/useClaudeStatus.test.ts
@@ -209,6 +209,30 @@ describe("useClaudeStatus", () => {
       expect(result.current.dismissedWaitingRef.current.has("/path/proj")).toBe(true);
     });
 
+    it("dismisses only the matching same-named worktree", async () => {
+      const refs = makeRefs();
+      refs.windowsRef.current = [
+        { id: 1, name: "proj", path: "/worktrees/one/proj", bundle_id: "com.microsoft.VSCode", editor_name: "VSCode" },
+        { id: 2, name: "proj", path: "/worktrees/two/proj", bundle_id: "com.microsoft.VSCode", editor_name: "VSCode" },
+      ];
+      const { result, emitClaudeStatus } = setup(refs);
+
+      await waitFor(() => expect(listen).toHaveBeenCalled());
+
+      act(() => {
+        emitClaudeStatus({
+          statuses: {
+            "/worktrees/one/proj": "waiting",
+            "/worktrees/two/proj": "waiting",
+          },
+        });
+        result.current.dismissWaitingForWindow(refs.windowsRef.current[1]);
+      });
+
+      expect(result.current.claudeStatuses["/worktrees/one/proj"]).toBe("waiting");
+      expect(result.current.claudeStatuses["/worktrees/two/proj"]).toBeUndefined();
+    });
+
     it("clears dismissed path when generating again", async () => {
       const refs = makeRefs();
       refs.windowsRef.current = [
@@ -302,6 +326,32 @@ describe("useClaudeStatus", () => {
       expect(result.current.claudeStatuses["/path/proj"]).toBeUndefined();
 
       vi.useRealTimers();
+    });
+  });
+
+  it("focuses the exact worktree when a notification is clicked", async () => {
+    const refs = makeRefs();
+    refs.windowsRef.current = [
+      { id: 1, name: "proj", path: "/worktrees/one/proj", bundle_id: "com.microsoft.VSCode", editor_name: "VSCode" },
+      { id: 2, name: "proj", path: "/worktrees/two/proj", bundle_id: "com.microsoft.VSCode", editor_name: "VSCode" },
+    ];
+    vi.mocked(invoke).mockResolvedValue(undefined);
+    const { listeners } = setup(refs);
+
+    await waitFor(() => expect(listeners.has("notification-clicked")).toBe(true));
+
+    act(() => {
+      const handler = listeners.get("notification-clicked") as unknown as (
+        event: { payload: { project_path: string } }
+      ) => void;
+      handler({ payload: { project_path: "/worktrees/two/proj" } });
+    });
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("focus_editor_window", {
+        bundle_id: "com.microsoft.VSCode",
+        window_id: 2,
+      });
     });
   });
 

--- a/src/hooks/useClaudeStatus.ts
+++ b/src/hooks/useClaudeStatus.ts
@@ -5,6 +5,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { isPermissionGranted, requestPermission } from "@tauri-apps/plugin-notification";
 import i18n from "../i18n";
 import type { EditorWindow, ClaudeStatus, ClaudeStatusPayload } from "../types/editor";
+import { projectPathMatchesWindow } from "../utils/store";
 
 interface UseClaudeStatusParams {
   windowsRef: MutableRefObject<EditorWindow[]>;
@@ -50,7 +51,7 @@ export function useClaudeStatus({
       if (
         status === "waiting" &&
         !dismissedWaitingRef.current.has(path) &&
-        path.split("/").pop() === activeWindow.name
+        projectPathMatchesWindow(path, activeWindow)
       ) {
         const timerId = setTimeout(() => {
           waitingTimersRef.current.delete(path);
@@ -75,7 +76,7 @@ export function useClaudeStatus({
 
   const dismissWaitingForWindow = useCallback((window: EditorWindow) => {
     const waitingKey = Object.entries(claudeStatusesRef.current).find(
-      ([path, status]) => status === "waiting" && path.split("/").pop() === window.name
+      ([path, status]) => status === "waiting" && projectPathMatchesWindow(path, window)
     )?.[0];
     if (waitingKey) {
       dismissedWaitingRef.current.add(waitingKey);
@@ -119,8 +120,6 @@ export function useClaudeStatus({
         if (!isMounted) return;
         const projectPath = event.payload.project_path;
         if (!projectPath) return;
-        const projectName = projectPath.split("/").pop() || projectPath;
-
         const appWindow = getCurrentWindow();
         await appWindow.show();
         isVisibleRef.current = true;
@@ -141,7 +140,7 @@ export function useClaudeStatus({
 
         await new Promise((r) => setTimeout(r, 500));
 
-        const win = windowsRef.current.find((w) => w.name === projectName);
+        const win = windowsRef.current.find((w) => projectPathMatchesWindow(projectPath, w));
         if (win) {
           await invoke("focus_editor_window", { bundle_id: win.bundle_id, window_id: win.id });
         } else if (windowsRef.current.length > 0) {

--- a/src/hooks/useEditorWindows.test.ts
+++ b/src/hooks/useEditorWindows.test.ts
@@ -1,22 +1,38 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import type { EditorWindow, EditorState } from "../types/editor";
+import type { EditorWindow, EditorState, GroupAssignment, GroupDefinition, TabColorMap } from "../types/editor";
 import { useEditorWindows } from "./useEditorWindows";
 
 // Mock store functions directly
 const mockLoadTabOrder = vi.fn<() => Promise<string[]>>().mockResolvedValue([]);
-const mockLoadTabColors = vi.fn<() => Promise<Record<string, string>>>().mockResolvedValue({});
+const mockLoadTabColors = vi.fn<() => Promise<TabColorMap>>().mockResolvedValue({});
 const mockSaveTabOrder = vi.fn().mockResolvedValue(undefined);
 const mockSaveTabColors = vi.fn().mockResolvedValue(undefined);
-const mockWindowKey = vi.fn((w: EditorWindow) => `${w.bundle_id}:${w.name}`);
+const mockLoadGroups = vi.fn<() => Promise<GroupDefinition[]>>().mockResolvedValue([]);
+const mockSaveGroups = vi.fn().mockResolvedValue(undefined);
+const mockLoadGroupAssignments = vi.fn<() => Promise<GroupAssignment>>().mockResolvedValue({});
+const mockSaveGroupAssignments = vi.fn().mockResolvedValue(undefined);
+const mockLoadCollapsedGroups = vi.fn<() => Promise<string[]>>().mockResolvedValue([]);
+const mockSaveCollapsedGroups = vi.fn().mockResolvedValue(undefined);
+const mockLoadGroupColors = vi.fn<() => Promise<Record<string, string>>>().mockResolvedValue({});
+const mockSaveGroupColors = vi.fn().mockResolvedValue(undefined);
+const mockWindowKey = vi.fn((w: EditorWindow) => `${w.bundle_id}:${w.path || w.name}`);
 const mockSortWindowsByOrder = vi.fn((windows: EditorWindow[], _order: string[]) => [...windows]);
 
 vi.mock("../utils/store", () => ({
   loadTabOrder: (...args: unknown[]) => mockLoadTabOrder(...(args as [])),
   loadTabColors: (...args: unknown[]) => mockLoadTabColors(...(args as [])),
   saveTabOrder: (...args: unknown[]) => mockSaveTabOrder(...(args as [string[]])),
-  saveTabColors: (...args: unknown[]) => mockSaveTabColors(...(args as [Record<string, string>])),
+  saveTabColors: (...args: unknown[]) => mockSaveTabColors(...(args as [TabColorMap])),
+  loadGroups: (...args: unknown[]) => mockLoadGroups(...(args as [])),
+  saveGroups: (...args: unknown[]) => mockSaveGroups(...args),
+  loadGroupAssignments: (...args: unknown[]) => mockLoadGroupAssignments(...(args as [])),
+  saveGroupAssignments: (...args: unknown[]) => mockSaveGroupAssignments(...args),
+  loadCollapsedGroups: (...args: unknown[]) => mockLoadCollapsedGroups(...(args as [])),
+  saveCollapsedGroups: (...args: unknown[]) => mockSaveCollapsedGroups(...args),
+  loadGroupColors: (...args: unknown[]) => mockLoadGroupColors(...(args as [])),
+  saveGroupColors: (...args: unknown[]) => mockSaveGroupColors(...args),
   windowKey: (w: EditorWindow) => mockWindowKey(w),
   sortWindowsByOrder: (windows: EditorWindow[], order: string[]) => mockSortWindowsByOrder(windows, order),
 }));
@@ -67,6 +83,14 @@ describe("useEditorWindows", () => {
     mockLoadTabColors.mockClear().mockResolvedValue({});
     mockSaveTabOrder.mockClear().mockResolvedValue(undefined);
     mockSaveTabColors.mockClear().mockResolvedValue(undefined);
+    mockLoadGroups.mockClear().mockResolvedValue([]);
+    mockSaveGroups.mockClear().mockResolvedValue(undefined);
+    mockLoadGroupAssignments.mockClear().mockResolvedValue({});
+    mockSaveGroupAssignments.mockClear().mockResolvedValue(undefined);
+    mockLoadCollapsedGroups.mockClear().mockResolvedValue([]);
+    mockSaveCollapsedGroups.mockClear().mockResolvedValue(undefined);
+    mockLoadGroupColors.mockClear().mockResolvedValue({});
+    mockSaveGroupColors.mockClear().mockResolvedValue(undefined);
     mockSortWindowsByOrder.mockClear().mockImplementation((windows) => [...windows]);
   });
 
@@ -174,6 +198,42 @@ describe("useEditorWindows", () => {
       expect(params.addToHistory).toHaveBeenCalledWith(
         expect.arrayContaining([expect.objectContaining({ name: "beta" })])
       );
+    });
+
+    it("updates a same-named window when its worktree path changes", async () => {
+      const first = makeWindow({ id: 1, name: "project", path: "/worktrees/one/project" });
+      const second = makeWindow({ id: 1, name: "project", path: "/worktrees/two/project" });
+      vi.mocked(invoke).mockResolvedValue([first]);
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.refreshWindows();
+      });
+
+      vi.mocked(invoke).mockResolvedValue([second]);
+      await act(async () => {
+        await result.current.refreshWindows();
+      });
+
+      expect(result.current.windows[0].path).toBe("/worktrees/two/project");
+    });
+
+    it("updates the window id when the same worktree is reopened", async () => {
+      const first = makeWindow({ id: 1, name: "project", path: "/worktrees/one/project" });
+      const reopened = makeWindow({ id: 2, name: "project", path: "/worktrees/one/project" });
+      vi.mocked(invoke).mockResolvedValue([first]);
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.refreshWindows();
+      });
+
+      vi.mocked(invoke).mockResolvedValue([reopened]);
+      await act(async () => {
+        await result.current.refreshWindows();
+      });
+
+      expect(result.current.windows[0].id).toBe(2);
     });
   });
 
@@ -370,7 +430,38 @@ describe("useEditorWindows", () => {
         result.current.handleColorChange("alpha", null);
       });
 
-      expect(result.current.tabColors.alpha).toBeUndefined();
+      expect(result.current.tabColors.alpha).toBeNull();
+    });
+
+    it("stores colors separately for same-named worktrees", () => {
+      const { result } = setup();
+      const firstKey = "com.microsoft.VSCode:/worktrees/one/project";
+      const secondKey = "com.microsoft.VSCode:/worktrees/two/project";
+
+      act(() => {
+        result.current.handleColorChange(firstKey, "red");
+        result.current.handleColorChange(secondKey, "blue");
+      });
+
+      expect(result.current.tabColors).toEqual({
+        [firstKey]: "red",
+        [secondKey]: "blue",
+      });
+    });
+  });
+
+  describe("group assignments", () => {
+    it("stores an explicit unassignment for a path-specific tab", () => {
+      const { result } = setup();
+      const key = "com.microsoft.VSCode:/worktrees/one/project";
+
+      act(() => {
+        result.current.assignTabToGroup(key, "group-a");
+        result.current.unassignTabFromGroup(key);
+      });
+
+      expect(result.current.groupAssignments[key]).toBeNull();
+      expect(mockSaveGroupAssignments).toHaveBeenLastCalledWith({ [key]: null });
     });
   });
 

--- a/src/hooks/useEditorWindows.test.ts
+++ b/src/hooks/useEditorWindows.test.ts
@@ -463,6 +463,36 @@ describe("useEditorWindows", () => {
       expect(result.current.groupAssignments[key]).toBeNull();
       expect(mockSaveGroupAssignments).toHaveBeenLastCalledWith({ [key]: null });
     });
+
+    it("updates repository window assignments in one batch", () => {
+      const { result } = setup();
+      const keys = [
+        "com.microsoft.VSCode:/worktrees/project",
+        "com.todesktop.230313mzl4w4u92:/projects/project",
+      ];
+
+      act(() => {
+        result.current.assignTabsToGroup(keys, "group-a");
+      });
+
+      expect(result.current.groupAssignments).toMatchObject({
+        [keys[0]]: "group-a",
+        [keys[1]]: "group-a",
+      });
+      expect(mockSaveGroupAssignments).toHaveBeenLastCalledWith({
+        [keys[0]]: "group-a",
+        [keys[1]]: "group-a",
+      });
+
+      act(() => {
+        result.current.unassignTabsFromGroup(keys);
+      });
+
+      expect(result.current.groupAssignments).toMatchObject({
+        [keys[0]]: null,
+        [keys[1]]: null,
+      });
+    });
   });
 
   describe("event listeners", () => {

--- a/src/hooks/useEditorWindows.test.ts
+++ b/src/hooks/useEditorWindows.test.ts
@@ -218,6 +218,30 @@ describe("useEditorWindows", () => {
       expect(result.current.windows[0].path).toBe("/worktrees/two/project");
     });
 
+    it("updates a window when repository metadata becomes available", async () => {
+      const initial = makeWindow({ repository_id: undefined, repository_name: undefined });
+      const resolved = makeWindow({
+        repository_id: "/projects/project/.git",
+        repository_name: "project",
+      });
+      vi.mocked(invoke).mockResolvedValue([initial]);
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.refreshWindows();
+      });
+
+      vi.mocked(invoke).mockResolvedValue([resolved]);
+      await act(async () => {
+        await result.current.refreshWindows();
+      });
+
+      expect(result.current.windows[0]).toMatchObject({
+        repository_id: "/projects/project/.git",
+        repository_name: "project",
+      });
+    });
+
     it("updates the window id when the same worktree is reopened", async () => {
       const first = makeWindow({ id: 1, name: "project", path: "/worktrees/one/project" });
       const reopened = makeWindow({ id: 2, name: "project", path: "/worktrees/one/project" });
@@ -456,8 +480,8 @@ describe("useEditorWindows", () => {
       const key = "com.microsoft.VSCode:/worktrees/one/project";
 
       act(() => {
-        result.current.assignTabToGroup(key, "group-a");
-        result.current.unassignTabFromGroup(key);
+        result.current.assignTabsToGroup([key], "group-a");
+        result.current.unassignTabsFromGroup([key]);
       });
 
       expect(result.current.groupAssignments[key]).toBeNull();

--- a/src/hooks/useEditorWindows.ts
+++ b/src/hooks/useEditorWindows.ts
@@ -59,13 +59,26 @@ interface UseEditorWindowsReturn {
   addGroup: (name: string) => string;
   updateGroup: (groupId: string, name: string) => void;
   deleteGroup: (groupId: string) => void;
-  assignTabToGroup: (wKey: string, groupId: string) => void;
-  unassignTabFromGroup: (wKey: string) => void;
   assignTabsToGroup: (wKeys: string[], groupId: string) => void;
   unassignTabsFromGroup: (wKeys: string[]) => void;
   toggleGroupCollapse: (groupId: string) => void;
   reorderGroups: (fromIndex: number, toIndex: number) => void;
   setGroupColor: (groupId: string, colorId: string | null) => void;
+}
+
+function editorWindowListsDiffer(next: EditorWindow[], current: EditorWindow[]): boolean {
+  return next.length !== current.length || next.some((window, index) => {
+    const previous = current[index];
+    return !previous ||
+      previous.id !== window.id ||
+      previous.name !== window.name ||
+      previous.path !== window.path ||
+      previous.branch !== window.branch ||
+      previous.repository_id !== window.repository_id ||
+      previous.repository_name !== window.repository_name ||
+      previous.bundle_id !== window.bundle_id ||
+      previous.editor_name !== window.editor_name;
+  });
 }
 
 export function useEditorWindows({
@@ -118,16 +131,7 @@ export function useEditorWindows({
       }
 
       const currentWindows = windowsRef.current;
-      const hasChanged =
-        sorted.length !== currentWindows.length ||
-        sorted.some(
-          (w, i) =>
-            currentWindows[i]?.id !== w.id ||
-            currentWindows[i]?.name !== w.name ||
-            currentWindows[i]?.path !== w.path ||
-            currentWindows[i]?.bundle_id !== w.bundle_id ||
-            currentWindows[i]?.branch !== w.branch
-        );
+      const hasChanged = editorWindowListsDiffer(sorted, currentWindows);
 
       if (hasChanged) {
         // Skip clearing windows on transient AX API empty response
@@ -370,16 +374,6 @@ export function useEditorWindows({
     });
   }, []);
 
-  const assignTabToGroup = useCallback(
-    (wKey: string, groupId: string) => assignTabsToGroup([wKey], groupId),
-    [assignTabsToGroup],
-  );
-
-  const unassignTabFromGroup = useCallback(
-    (wKey: string) => unassignTabsFromGroup([wKey]),
-    [unassignTabsFromGroup],
-  );
-
   const toggleGroupCollapse = useCallback((groupId: string) => {
     setCollapsedGroups((prev) => {
       const next = new Set(prev);
@@ -445,16 +439,7 @@ export function useEditorWindows({
       tabOrderRef.current = sorted.map((w) => windowKey(w));
 
       const currentWindows = windowsRef.current;
-      const hasChanged =
-        sorted.length !== currentWindows.length ||
-        sorted.some(
-          (w, i) =>
-            currentWindows[i]?.id !== w.id ||
-            currentWindows[i]?.name !== w.name ||
-            currentWindows[i]?.path !== w.path ||
-            currentWindows[i]?.bundle_id !== w.bundle_id ||
-            currentWindows[i]?.branch !== w.branch
-        );
+      const hasChanged = editorWindowListsDiffer(sorted, currentWindows);
 
       if (hasChanged) {
         // Skip clearing windows on transient AX API empty response
@@ -606,16 +591,7 @@ export function useEditorWindows({
         }
 
         const currentWindows = windowsRef.current;
-        const windowsChanged =
-          sorted.length !== currentWindows.length ||
-          sorted.some(
-            (w, i) =>
-              currentWindows[i]?.id !== w.id ||
-              currentWindows[i]?.name !== w.name ||
-              currentWindows[i]?.path !== w.path ||
-              currentWindows[i]?.bundle_id !== w.bundle_id ||
-              currentWindows[i]?.branch !== w.branch
-          );
+        const windowsChanged = editorWindowListsDiffer(sorted, currentWindows);
 
         if (windowsChanged) {
           const newKeys = new Set(sorted.map((w) => windowKey(w)));
@@ -680,8 +656,6 @@ export function useEditorWindows({
     addGroup,
     updateGroup,
     deleteGroup,
-    assignTabToGroup,
-    unassignTabFromGroup,
     assignTabsToGroup,
     unassignTabsFromGroup,
     toggleGroupCollapse,

--- a/src/hooks/useEditorWindows.ts
+++ b/src/hooks/useEditorWindows.ts
@@ -5,7 +5,7 @@ import { getCurrentWindow, PhysicalPosition } from "@tauri-apps/api/window";
 import { ask } from "@tauri-apps/plugin-dialog";
 import type { TFunction } from "i18next";
 import { TAB_BAR_HEIGHT, ALL_EDITOR_BUNDLE_IDS } from "../types/editor";
-import type { EditorWindow, EditorState, GroupDefinition, GroupAssignment } from "../types/editor";
+import type { EditorWindow, EditorState, GroupDefinition, GroupAssignment, TabColorMap } from "../types/editor";
 import {
   loadTabOrder,
   loadTabColors,
@@ -37,7 +37,7 @@ interface UseEditorWindowsParams {
 interface UseEditorWindowsReturn {
   windows: EditorWindow[];
   activeIndex: number;
-  tabColors: Record<string, string>;
+  tabColors: TabColorMap;
   groups: GroupDefinition[];
   groupAssignments: GroupAssignment;
   collapsedGroups: Set<string>;
@@ -55,7 +55,7 @@ interface UseEditorWindowsReturn {
   handleCloseTab: (index: number) => Promise<void>;
   handleReorder: (from: number, to: number) => void;
   handleReorderByVisual: (visualOrder: number[]) => void;
-  handleColorChange: (name: string, colorId: string | null) => void;
+  handleColorChange: (windowKey: string, colorId: string | null) => void;
   addGroup: (name: string) => string;
   updateGroup: (groupId: string, name: string) => void;
   deleteGroup: (groupId: string) => void;
@@ -78,7 +78,7 @@ export function useEditorWindows({
 }: UseEditorWindowsParams): UseEditorWindowsReturn {
   const [windows, setWindows] = useState<EditorWindow[]>([]);
   const [activeIndex, setActiveIndex] = useState<number>(0);
-  const [tabColors, setTabColors] = useState<Record<string, string>>({});
+  const [tabColors, setTabColors] = useState<TabColorMap>({});
   const [groups, setGroups] = useState<GroupDefinition[]>([]);
   const [groupAssignments, setGroupAssignments] = useState<GroupAssignment>({});
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
@@ -120,7 +120,9 @@ export function useEditorWindows({
         sorted.length !== currentWindows.length ||
         sorted.some(
           (w, i) =>
+            currentWindows[i]?.id !== w.id ||
             currentWindows[i]?.name !== w.name ||
+            currentWindows[i]?.path !== w.path ||
             currentWindows[i]?.bundle_id !== w.bundle_id ||
             currentWindows[i]?.branch !== w.branch
         );
@@ -287,13 +289,13 @@ export function useEditorWindows({
     setActiveIndex(Math.max(newActiveIndex, 0));
   }, []);
 
-  const handleColorChange = useCallback((windowName: string, colorId: string | null) => {
+  const handleColorChange = useCallback((key: string, colorId: string | null) => {
     setTabColors((prev) => {
       const next = { ...prev };
       if (colorId === null) {
-        delete next[windowName];
+        next[key] = null;
       } else {
-        next[windowName] = colorId;
+        next[key] = colorId;
       }
       saveTabColors(next);
       return next;
@@ -358,8 +360,7 @@ export function useEditorWindows({
 
   const unassignTabFromGroup = useCallback((wKey: string) => {
     setGroupAssignments((prev) => {
-      const next = { ...prev };
-      delete next[wKey];
+      const next = { ...prev, [wKey]: null };
       saveGroupAssignments(next);
       return next;
     });
@@ -434,7 +435,9 @@ export function useEditorWindows({
         sorted.length !== currentWindows.length ||
         sorted.some(
           (w, i) =>
+            currentWindows[i]?.id !== w.id ||
             currentWindows[i]?.name !== w.name ||
+            currentWindows[i]?.path !== w.path ||
             currentWindows[i]?.bundle_id !== w.bundle_id ||
             currentWindows[i]?.branch !== w.branch
         );
@@ -593,7 +596,9 @@ export function useEditorWindows({
           sorted.length !== currentWindows.length ||
           sorted.some(
             (w, i) =>
+              currentWindows[i]?.id !== w.id ||
               currentWindows[i]?.name !== w.name ||
+              currentWindows[i]?.path !== w.path ||
               currentWindows[i]?.bundle_id !== w.bundle_id ||
               currentWindows[i]?.branch !== w.branch
           );

--- a/src/hooks/useEditorWindows.ts
+++ b/src/hooks/useEditorWindows.ts
@@ -61,6 +61,8 @@ interface UseEditorWindowsReturn {
   deleteGroup: (groupId: string) => void;
   assignTabToGroup: (wKey: string, groupId: string) => void;
   unassignTabFromGroup: (wKey: string) => void;
+  assignTabsToGroup: (wKeys: string[], groupId: string) => void;
+  unassignTabsFromGroup: (wKeys: string[]) => void;
   toggleGroupCollapse: (groupId: string) => void;
   reorderGroups: (fromIndex: number, toIndex: number) => void;
   setGroupColor: (groupId: string, colorId: string | null) => void;
@@ -350,21 +352,33 @@ export function useEditorWindows({
     });
   }, []);
 
-  const assignTabToGroup = useCallback((wKey: string, groupId: string) => {
+  const assignTabsToGroup = useCallback((wKeys: string[], groupId: string) => {
     setGroupAssignments((prev) => {
-      const next = { ...prev, [wKey]: groupId };
+      const next = { ...prev };
+      for (const wKey of wKeys) next[wKey] = groupId;
       saveGroupAssignments(next);
       return next;
     });
   }, []);
 
-  const unassignTabFromGroup = useCallback((wKey: string) => {
+  const unassignTabsFromGroup = useCallback((wKeys: string[]) => {
     setGroupAssignments((prev) => {
-      const next = { ...prev, [wKey]: null };
+      const next = { ...prev };
+      for (const wKey of wKeys) next[wKey] = null;
       saveGroupAssignments(next);
       return next;
     });
   }, []);
+
+  const assignTabToGroup = useCallback(
+    (wKey: string, groupId: string) => assignTabsToGroup([wKey], groupId),
+    [assignTabsToGroup],
+  );
+
+  const unassignTabFromGroup = useCallback(
+    (wKey: string) => unassignTabsFromGroup([wKey]),
+    [unassignTabsFromGroup],
+  );
 
   const toggleGroupCollapse = useCallback((groupId: string) => {
     setCollapsedGroups((prev) => {
@@ -668,6 +682,8 @@ export function useEditorWindows({
     deleteGroup,
     assignTabToGroup,
     unassignTabFromGroup,
+    assignTabsToGroup,
+    unassignTabsFromGroup,
     toggleGroupCollapse,
     reorderGroups,
     setGroupColor,

--- a/src/hooks/useHistory.test.ts
+++ b/src/hooks/useHistory.test.ts
@@ -11,6 +11,7 @@ const mockSaveHistory = vi.fn<(entries: HistoryEntry[]) => Promise<void>>().mock
 vi.mock("../utils/store", () => ({
   loadHistory: (...args: unknown[]) => mockLoadHistory(...(args as [])),
   saveHistory: (...args: unknown[]) => mockSaveHistory(...(args as [HistoryEntry[]])),
+  normalizeProjectPath: (path: string) => path.replace(/\/+$/, ""),
 }));
 
 function makeWindow(overrides: Partial<EditorWindow> = {}): EditorWindow {
@@ -97,9 +98,9 @@ describe("useHistory", () => {
       expect(result.current.history).toHaveLength(0);
     });
 
-    it("deduplicates by name+bundleId", async () => {
+    it("deduplicates by path+bundleId", async () => {
       const existing: HistoryEntry[] = [
-        { name: "proj", path: "/old", bundleId: "com.microsoft.VSCode", editorName: "VSCode", timestamp: 1000 },
+        { name: "old-name", path: "/worktrees/one/proj", bundleId: "com.microsoft.VSCode", editorName: "VSCode", timestamp: 1000 },
       ];
       const { result } = setup(existing);
 
@@ -107,13 +108,35 @@ describe("useHistory", () => {
         expect(result.current.history).toHaveLength(1);
       });
 
-      const win = makeWindow({ name: "proj", path: "/new" });
+      const win = makeWindow({ name: "proj", path: "/worktrees/one/proj" });
       act(() => {
         result.current.addToHistory([win]);
       });
 
       expect(result.current.history).toHaveLength(1);
-      expect(result.current.history[0].path).toBe("/new");
+      expect(result.current.history[0].name).toBe("proj");
+    });
+
+    it("keeps same-named worktrees as separate history entries", async () => {
+      const existing: HistoryEntry[] = [
+        { name: "proj", path: "/worktrees/one/proj", bundleId: "com.microsoft.VSCode", editorName: "VSCode", timestamp: 1000 },
+      ];
+      const { result } = setup(existing);
+
+      await waitFor(() => {
+        expect(result.current.history).toHaveLength(1);
+      });
+
+      act(() => {
+        result.current.addToHistory([
+          makeWindow({ name: "proj", path: "/worktrees/two/proj" }),
+        ]);
+      });
+
+      expect(result.current.history.map((entry) => entry.path)).toEqual([
+        "/worktrees/two/proj",
+        "/worktrees/one/proj",
+      ]);
     });
 
     it("respects MAX_HISTORY_ENTRIES limit", async () => {

--- a/src/hooks/useHistory.ts
+++ b/src/hooks/useHistory.ts
@@ -2,7 +2,7 @@ import { useEffect, useState, useCallback, useRef, type MutableRefObject } from 
 import { invoke } from "@tauri-apps/api/core";
 import { EDITOR_DISPLAY_NAMES, MAX_HISTORY_ENTRIES } from "../types/editor";
 import type { EditorWindow, HistoryEntry } from "../types/editor";
-import { loadHistory, saveHistory } from "../utils/store";
+import { loadHistory, normalizeProjectPath, saveHistory } from "../utils/store";
 
 interface UseHistoryParams {
   refreshWindowsRef: MutableRefObject<() => Promise<void>>;
@@ -55,7 +55,10 @@ export function useHistory({ refreshWindowsRef }: UseHistoryParams): UseHistoryR
         const editorName = EDITOR_DISPLAY_NAMES[bundleId] || win.editor_name || bundleId;
 
         updated = updated.filter(
-          (e) => !(e.name === win.name && e.bundleId === bundleId)
+          (e) => !(
+            normalizeProjectPath(e.path) === normalizeProjectPath(win.path) &&
+            e.bundleId === bundleId
+          )
         );
 
         updated.unshift({

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -9,6 +9,11 @@
     "newEditorTooltip": "Open new editor window (Cmd+Shift+T)",
     "closeTooltip": "Close (Cmd+W)"
   },
+  "worktree": {
+    "openBranches": "Open {{name}} branches",
+    "branchList": "{{name}} branches",
+    "closeBranch": "Close {{branch}}"
+  },
   "settings": {
     "title": "Settings",
     "claudeIntegration": "Claude Code Integration",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -9,6 +9,11 @@
     "newEditorTooltip": "新しいエディタウィンドウを開く (Cmd+Shift+T)",
     "closeTooltip": "閉じる (Cmd+W)"
   },
+  "worktree": {
+    "openBranches": "{{name}}のブランチを開く",
+    "branchList": "{{name}}のブランチ",
+    "closeBranch": "{{branch}}を閉じる"
+  },
   "settings": {
     "title": "設定",
     "claudeIntegration": "Claude Code 連携",

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -6,6 +6,8 @@ export interface EditorWindow {
   name: string;
   path: string;
   branch?: string;
+  repository_id?: string;
+  repository_name?: string;
   bundle_id: string;
   editor_name: string;
 }

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -52,8 +52,11 @@ export interface GroupDefinition {
 }
 
 export interface GroupAssignment {
-  [windowKey: string]: string; // windowKey -> groupId
+  [windowKey: string]: string | null; // null prevents legacy-key fallback after unassigning
 }
+
+// null prevents a cleared path-specific color from falling back to a legacy name key
+export type TabColorMap = Record<string, string | null>;
 
 // Claude Code status
 export type ClaudeStatus = "waiting" | "generating";

--- a/src/utils/repositoryTabs.test.ts
+++ b/src/utils/repositoryTabs.test.ts
@@ -1,5 +1,9 @@
 import type { EditorWindow } from "../types/editor";
-import { groupRepositoryTabs, type TabEntry } from "./repositoryTabs";
+import {
+  getInheritedRepositoryGroupId,
+  groupRepositoryTabs,
+  type TabEntry,
+} from "./repositoryTabs";
 
 function makeEntry(index: number, overrides: Partial<EditorWindow> = {}): TabEntry {
   return {
@@ -19,7 +23,7 @@ function makeEntry(index: number, overrides: Partial<EditorWindow> = {}): TabEnt
 }
 
 describe("groupRepositoryTabs", () => {
-  it("groups worktrees from the same repository and editor", () => {
+  it("groups worktrees from the same repository", () => {
     const result = groupRepositoryTabs([makeEntry(0), makeEntry(1)]);
 
     expect(result).toHaveLength(1);
@@ -35,13 +39,17 @@ describe("groupRepositoryTabs", () => {
     expect(groupRepositoryTabs([entry])).toEqual([{ type: "tab", entry }]);
   });
 
-  it("does not group the same repository across different editors", () => {
+  it("groups the same repository across different editors", () => {
     const result = groupRepositoryTabs([
       makeEntry(0),
       makeEntry(1, { bundle_id: "com.todesktop.230313mzl4w4u92" }),
     ]);
 
-    expect(result.map((item) => item.type)).toEqual(["tab", "tab"]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: "repository",
+      entries: [{ originalIndex: 0 }, { originalIndex: 1 }],
+    });
   });
 
   it("does not group different repositories", () => {
@@ -62,5 +70,29 @@ describe("groupRepositoryTabs", () => {
 
     expect(result[0]).toEqual({ type: "tab", entry: standalone });
     expect(result[1]).toMatchObject({ type: "repository", entries: [firstWorktree, secondWorktree] });
+  });
+});
+
+describe("getInheritedRepositoryGroupId", () => {
+  const entries = [makeEntry(0), makeEntry(1)];
+
+  it("inherits the only assigned manual group", () => {
+    const result = getInheritedRepositoryGroupId(entries, ({ originalIndex }) =>
+      originalIndex === 0 ? "medii" : null
+    );
+
+    expect(result).toBe("medii");
+  });
+
+  it("stays ungrouped when child assignments conflict", () => {
+    const result = getInheritedRepositoryGroupId(entries, ({ originalIndex }) =>
+      originalIndex === 0 ? "medii" : "personal"
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("stays ungrouped when no child is assigned", () => {
+    expect(getInheritedRepositoryGroupId(entries, () => null)).toBeNull();
   });
 });

--- a/src/utils/repositoryTabs.test.ts
+++ b/src/utils/repositoryTabs.test.ts
@@ -1,0 +1,66 @@
+import type { EditorWindow } from "../types/editor";
+import { groupRepositoryTabs, type TabEntry } from "./repositoryTabs";
+
+function makeEntry(index: number, overrides: Partial<EditorWindow> = {}): TabEntry {
+  return {
+    originalIndex: index,
+    tab: {
+      id: index + 1,
+      name: `project-${index}`,
+      path: `/worktrees/project-${index}`,
+      branch: `branch-${index}`,
+      repository_id: `/projects/project/.git`,
+      repository_name: "project",
+      bundle_id: "com.microsoft.VSCode",
+      editor_name: "VSCode",
+      ...overrides,
+    },
+  };
+}
+
+describe("groupRepositoryTabs", () => {
+  it("groups worktrees from the same repository and editor", () => {
+    const result = groupRepositoryTabs([makeEntry(0), makeEntry(1)]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: "repository",
+      name: "project",
+      entries: [{ originalIndex: 0 }, { originalIndex: 1 }],
+    });
+  });
+
+  it("keeps a single repository window as a normal tab", () => {
+    const entry = makeEntry(0);
+    expect(groupRepositoryTabs([entry])).toEqual([{ type: "tab", entry }]);
+  });
+
+  it("does not group the same repository across different editors", () => {
+    const result = groupRepositoryTabs([
+      makeEntry(0),
+      makeEntry(1, { bundle_id: "com.todesktop.230313mzl4w4u92" }),
+    ]);
+
+    expect(result.map((item) => item.type)).toEqual(["tab", "tab"]);
+  });
+
+  it("does not group different repositories", () => {
+    const result = groupRepositoryTabs([
+      makeEntry(0),
+      makeEntry(1, { repository_id: "/projects/another/.git", repository_name: "another" }),
+    ]);
+
+    expect(result.map((item) => item.type)).toEqual(["tab", "tab"]);
+  });
+
+  it("keeps the first repository position in the tab order", () => {
+    const standalone = makeEntry(0, { repository_id: undefined, repository_name: undefined });
+    const firstWorktree = makeEntry(1);
+    const secondWorktree = makeEntry(2);
+
+    const result = groupRepositoryTabs([standalone, firstWorktree, secondWorktree]);
+
+    expect(result[0]).toEqual({ type: "tab", entry: standalone });
+    expect(result[1]).toMatchObject({ type: "repository", entries: [firstWorktree, secondWorktree] });
+  });
+});

--- a/src/utils/repositoryTabs.ts
+++ b/src/utils/repositoryTabs.ts
@@ -1,0 +1,50 @@
+import type { EditorWindow } from "../types/editor";
+
+export interface TabEntry {
+  tab: EditorWindow;
+  originalIndex: number;
+}
+
+export type RepositoryTabItem =
+  | { type: "tab"; entry: TabEntry }
+  | { type: "repository"; key: string; name: string; entries: TabEntry[] };
+
+function repositoryKey(tab: EditorWindow): string | null {
+  if (!tab.repository_id) return null;
+  return `${tab.bundle_id}:${tab.repository_id}`;
+}
+
+export function groupRepositoryTabs(entries: TabEntry[]): RepositoryTabItem[] {
+  const repositoryEntries = new Map<string, TabEntry[]>();
+
+  for (const entry of entries) {
+    const key = repositoryKey(entry.tab);
+    if (!key) continue;
+    const grouped = repositoryEntries.get(key) ?? [];
+    grouped.push(entry);
+    repositoryEntries.set(key, grouped);
+  }
+
+  const renderedRepositories = new Set<string>();
+  const result: RepositoryTabItem[] = [];
+
+  for (const entry of entries) {
+    const key = repositoryKey(entry.tab);
+    const grouped = key ? repositoryEntries.get(key) : undefined;
+    if (!key || !grouped || grouped.length === 1) {
+      result.push({ type: "tab", entry });
+      continue;
+    }
+    if (renderedRepositories.has(key)) continue;
+
+    renderedRepositories.add(key);
+    result.push({
+      type: "repository",
+      key,
+      name: entry.tab.repository_name || entry.tab.name,
+      entries: grouped,
+    });
+  }
+
+  return result;
+}

--- a/src/utils/repositoryTabs.ts
+++ b/src/utils/repositoryTabs.ts
@@ -11,7 +11,19 @@ export type RepositoryTabItem =
 
 function repositoryKey(tab: EditorWindow): string | null {
   if (!tab.repository_id) return null;
-  return `${tab.bundle_id}:${tab.repository_id}`;
+  return tab.repository_id;
+}
+
+export function getInheritedRepositoryGroupId(
+  entries: TabEntry[],
+  getGroupId: (entry: TabEntry) => string | null | undefined,
+): string | null {
+  const groupIds = new Set(
+    entries
+      .map(getGroupId)
+      .filter((groupId): groupId is string => Boolean(groupId)),
+  );
+  return groupIds.size === 1 ? [...groupIds][0] : null;
 }
 
 export function groupRepositoryTabs(entries: TabEntry[]): RepositoryTabItem[] {

--- a/src/utils/store.test.ts
+++ b/src/utils/store.test.ts
@@ -6,6 +6,7 @@ import {
   legacyWindowKey,
   normalizeProjectPath,
   projectPathMatchesWindow,
+  repositoryColorKey,
   windowKey,
   sortWindowsByOrder,
   UNIFIED_ORDER_KEY,
@@ -52,6 +53,12 @@ describe("windowKey", () => {
   it("falls back to the legacy key when path is unavailable", () => {
     const w = makeWindow({ name: "proj", path: "" });
     expect(windowKey(w)).toBe(legacyWindowKey(w));
+  });
+});
+
+describe("repositoryColorKey", () => {
+  it("keeps repository colors separate from window colors", () => {
+    expect(repositoryColorKey("/projects/sample/.git")).toBe("repository:/projects/sample/.git");
   });
 });
 

--- a/src/utils/store.test.ts
+++ b/src/utils/store.test.ts
@@ -2,6 +2,10 @@ import { load } from "@tauri-apps/plugin-store";
 import { createMockStore } from "../test/setup";
 import type { EditorWindow } from "../types/editor";
 import {
+  getWindowScopedValue,
+  legacyWindowKey,
+  normalizeProjectPath,
+  projectPathMatchesWindow,
   windowKey,
   sortWindowsByOrder,
   UNIFIED_ORDER_KEY,
@@ -28,22 +32,62 @@ function makeWindow(overrides: Partial<EditorWindow> = {}): EditorWindow {
 // ────────────────────────────────
 
 describe("windowKey", () => {
-  it("returns bundle_id:name format", () => {
-    const w = makeWindow({ bundle_id: "com.microsoft.VSCode", name: "proj" });
-    expect(windowKey(w)).toBe("com.microsoft.VSCode:proj");
+  it("returns bundle_id:path format", () => {
+    const w = makeWindow({ bundle_id: "com.microsoft.VSCode", path: "/worktrees/one/proj" });
+    expect(windowKey(w)).toBe("com.microsoft.VSCode:/worktrees/one/proj");
   });
 
   it("handles different editors with same project name", () => {
-    const a = makeWindow({ bundle_id: "com.microsoft.VSCode", name: "proj" });
-    const b = makeWindow({ bundle_id: "dev.zed.Zed", name: "proj" });
+    const a = makeWindow({ bundle_id: "com.microsoft.VSCode", name: "proj", path: "/worktrees/one/proj" });
+    const b = makeWindow({ bundle_id: "dev.zed.Zed", name: "proj", path: "/worktrees/one/proj" });
     expect(windowKey(a)).not.toBe(windowKey(b));
+  });
+
+  it("handles same-named worktrees in the same editor", () => {
+    const a = makeWindow({ name: "proj", path: "/worktrees/one/proj" });
+    const b = makeWindow({ name: "proj", path: "/worktrees/two/proj" });
+    expect(windowKey(a)).not.toBe(windowKey(b));
+  });
+
+  it("falls back to the legacy key when path is unavailable", () => {
+    const w = makeWindow({ name: "proj", path: "" });
+    expect(windowKey(w)).toBe(legacyWindowKey(w));
+  });
+});
+
+describe("window path matching", () => {
+  it("matches the exact worktree path", () => {
+    const window = makeWindow({ name: "proj", path: "/worktrees/one/proj" });
+    expect(projectPathMatchesWindow("/worktrees/one/proj/", window)).toBe(true);
+    expect(projectPathMatchesWindow("/worktrees/two/proj", window)).toBe(false);
+  });
+
+  it("falls back to the project name when path is unavailable", () => {
+    const window = makeWindow({ name: "proj", path: "" });
+    expect(projectPathMatchesWindow("/worktrees/one/proj", window)).toBe(true);
+  });
+
+  it("uses an explicit path value before a legacy value", () => {
+    const window = makeWindow({ name: "proj", path: "/worktrees/one/proj" });
+    const values = { [windowKey(window)]: null, proj: "blue" };
+    expect(getWindowScopedValue(values, window, window.name)).toBeNull();
+  });
+
+  it("reads a legacy group assignment when no path-specific value exists", () => {
+    const window = makeWindow({ name: "proj", path: "/worktrees/one/proj" });
+    const values = { [legacyWindowKey(window)]: "group-a" };
+    expect(getWindowScopedValue(values, window, legacyWindowKey(window))).toBe("group-a");
+  });
+
+  it("normalizes trailing slashes", () => {
+    expect(normalizeProjectPath("/worktrees/one/proj///")).toBe("/worktrees/one/proj");
   });
 });
 
 describe("sortWindowsByOrder", () => {
-  const w1 = makeWindow({ name: "alpha", bundle_id: "com.microsoft.VSCode" });
-  const w2 = makeWindow({ name: "beta", bundle_id: "com.microsoft.VSCode" });
-  const w3 = makeWindow({ name: "gamma", bundle_id: "dev.zed.Zed" });
+  const w1 = makeWindow({ name: "alpha", path: "/projects/alpha", bundle_id: "com.microsoft.VSCode" });
+  const w2 = makeWindow({ name: "beta", path: "/projects/beta", bundle_id: "com.microsoft.VSCode" });
+  const w3 = makeWindow({ name: "gamma", path: "/projects/gamma", bundle_id: "dev.zed.Zed" });
 
   it("sorts by custom order", () => {
     const order = [windowKey(w3), windowKey(w1), windowKey(w2)];
@@ -58,6 +102,12 @@ describe("sortWindowsByOrder", () => {
     // new windows alphabetically
     expect(result[1].name).toBe("alpha");
     expect(result[2].name).toBe("gamma");
+  });
+
+  it("supports an order saved with legacy name-based keys", () => {
+    const order = [legacyWindowKey(w2)];
+    const result = sortWindowsByOrder([w1, w2], order);
+    expect(result.map((w) => w.name)).toEqual(["beta", "alpha"]);
   });
 
   it("returns empty array for empty input", () => {

--- a/src/utils/store.ts
+++ b/src/utils/store.ts
@@ -1,6 +1,6 @@
 import { load } from "@tauri-apps/plugin-store";
 import type { Store } from "@tauri-apps/plugin-store";
-import type { EditorWindow, GroupAssignment, GroupDefinition, HistoryEntry } from "../types/editor";
+import type { EditorWindow, GroupAssignment, GroupDefinition, HistoryEntry, TabColorMap } from "../types/editor";
 
 // Store instance (lazily initialized)
 let storePromise: Promise<Store> | null = null;
@@ -43,8 +43,8 @@ async function saveValue<T>(key: string, value: T): Promise<void> {
 
 export const loadTabOrder = () => loadValue<string[]>(UNIFIED_ORDER_KEY, []);
 export const saveTabOrder = (order: string[]) => saveValue(UNIFIED_ORDER_KEY, order);
-export const loadTabColors = () => loadValue<Record<string, string>>(UNIFIED_COLOR_KEY, {});
-export const saveTabColors = (colors: Record<string, string>) => saveValue(UNIFIED_COLOR_KEY, colors);
+export const loadTabColors = () => loadValue<TabColorMap>(UNIFIED_COLOR_KEY, {});
+export const saveTabColors = (colors: TabColorMap) => saveValue(UNIFIED_COLOR_KEY, colors);
 export const loadHistory = () => loadValue<HistoryEntry[]>("history", []);
 export const saveHistory = (entries: HistoryEntry[]) => saveValue("history", entries);
 export const loadGroups = () => loadValue<GroupDefinition[]>(GROUPS_DEFINITIONS_KEY, []);
@@ -56,17 +56,46 @@ export const saveCollapsedGroups = (collapsedIds: string[]) => saveValue(GROUPS_
 export const loadGroupColors = () => loadValue<Record<string, string>>(GROUPS_COLORS_KEY, {});
 export const saveGroupColors = (colors: Record<string, string>) => saveValue(GROUPS_COLORS_KEY, colors);
 
-// Unique key for a window in the unified tab bar (handles same project name in different editors)
-export function windowKey(w: EditorWindow): string {
+export function normalizeProjectPath(path: string): string {
+  return path.length > 1 ? path.replace(/\/+$/, "") : path;
+}
+
+export function legacyWindowKey(w: EditorWindow): string {
   return `${w.bundle_id}:${w.name}`;
+}
+
+// Unique key for a window in the unified tab bar (handles worktrees with the same project name)
+export function windowKey(w: EditorWindow): string {
+  const identity = w.path ? normalizeProjectPath(w.path) : w.name;
+  return `${w.bundle_id}:${identity}`;
+}
+
+export function projectPathMatchesWindow(projectPath: string, window: EditorWindow): boolean {
+  const normalizedProjectPath = normalizeProjectPath(projectPath);
+  if (window.path) {
+    return normalizedProjectPath === normalizeProjectPath(window.path);
+  }
+  return normalizedProjectPath.split("/").pop() === window.name;
+}
+
+export function getWindowScopedValue<T>(
+  values: Record<string, T>,
+  window: EditorWindow,
+  legacyKey: string,
+): T | undefined {
+  const key = windowKey(window);
+  if (Object.prototype.hasOwnProperty.call(values, key)) {
+    return values[key];
+  }
+  return values[legacyKey];
 }
 
 // Sort windows by custom order, new windows go to the end
 export function sortWindowsByOrder(windows: EditorWindow[], order: string[]): EditorWindow[] {
   const orderMap = new Map(order.map((key, index) => [key, index]));
   return [...windows].sort((a, b) => {
-    const indexA = orderMap.get(windowKey(a)) ?? Infinity;
-    const indexB = orderMap.get(windowKey(b)) ?? Infinity;
+    const indexA = orderMap.get(windowKey(a)) ?? orderMap.get(legacyWindowKey(a)) ?? Infinity;
+    const indexB = orderMap.get(windowKey(b)) ?? orderMap.get(legacyWindowKey(b)) ?? Infinity;
     if (indexA === Infinity && indexB === Infinity) {
       return a.name.localeCompare(b.name);
     }

--- a/src/utils/store.ts
+++ b/src/utils/store.ts
@@ -70,6 +70,10 @@ export function windowKey(w: EditorWindow): string {
   return `${w.bundle_id}:${identity}`;
 }
 
+export function repositoryColorKey(repositoryId: string): string {
+  return `repository:${repositoryId}`;
+}
+
 export function projectPathMatchesWindow(projectPath: string, window: EditorWindow): boolean {
   const normalizedProjectPath = normalizeProjectPath(projectPath);
   if (window.path) {


### PR DESCRIPTION
## Summary

- resolve editor windows to their exact workspace paths so same-named Git worktrees remain distinct
- identify linked worktrees by their shared Git directory and group them under one repository tab across editors
- open the branch list on click and show the owning editor for cross-editor entries
- inherit a repository's single manual group and apply parent group changes to every child window
- scope tab order, colors, groups, history, and Codex status handling by editor and project path
- preserve legacy name-based settings as fallbacks

## Why

- repository windows were still split when they belonged to different editors or manual-group sections
- hover opening was unreliable while the tab manager was not the active macOS application

## Validation

- `pnpm exec vitest run` (113 tests passed)
- `pnpm build`
- `cargo test --manifest-path src-tauri/Cargo.toml` (38 tests passed)
- `cargo clippy --manifest-path src-tauri/Cargo.toml`
- `git diff --check`

## Known issues

- `cargo clippy` still reports two pre-existing `manual_c_str_literals` warnings in `src-tauri/src/notification.rs`.
