### PR TITLE
feat: add list layout and stabilize worktree tabs

### DIFF
--- a/src-tauri/src/ax_helper.rs
+++ b/src-tauri/src/ax_helper.rs
@@ -4,13 +4,16 @@
 //! instead of slower AppleScript calls.
 
 use accessibility::{AXUIElement, AXUIElementActions, AXUIElementAttributes};
-use accessibility_sys::AXUIElementRef;
+use accessibility_sys::{AXUIElementGetPid, AXUIElementRef};
 use core_foundation::boolean::CFBoolean;
 use core_foundation::base::TCFType;
 use core_foundation::string::CFString;
 use core_graphics::window::CGWindowID;
 use objc2_app_kit::NSRunningApplication;
 use objc2_foundation::NSString;
+use std::collections::HashSet;
+
+use crate::editor_model::NativeEditorWindow;
 
 // Private API declaration for getting CGWindowID from AXUIElement
 #[link(name = "ApplicationServices", kind = "framework")]
@@ -48,9 +51,11 @@ pub fn get_pid_by_bundle_id(bundle_id: &str) -> Option<i32> {
     None
 }
 
-/// Get all windows for an application by PID
-/// Returns a vector of (window_id, window_title, is_frontmost) tuples
-pub fn get_windows_ax(pid: i32) -> Result<Vec<(u32, String, bool)>, String> {
+pub fn get_native_windows_ax(
+    pid: i32,
+    bundle_id: &str,
+    include_renderer_pids: bool,
+) -> Result<Vec<NativeEditorWindow>, String> {
     let app = AXUIElement::application(pid);
 
     // Get windows attribute
@@ -90,10 +95,64 @@ pub fn get_windows_ax(pid: i32) -> Result<Vec<(u32, String, bool)>, String> {
             .map(|fw| windows_equal(&window, fw))
             .unwrap_or(false);
 
-        result.push((window_id, title, is_frontmost));
+        let renderer_pids = if include_renderer_pids {
+            descendant_process_ids(&window, pid)
+        } else {
+            Vec::new()
+        };
+
+        result.push(NativeEditorWindow::new(
+            bundle_id,
+            pid,
+            window_id,
+            title,
+            is_frontmost,
+            renderer_pids,
+        ));
     }
 
     Ok(result)
+}
+
+fn descendant_process_ids(window: &AXUIElement, editor_pid: i32) -> Vec<i32> {
+    const MAX_DEPTH: usize = 8;
+    const MAX_ELEMENTS: usize = 512;
+
+    fn visit(
+        element: &AXUIElement,
+        editor_pid: i32,
+        depth: usize,
+        visited: &mut usize,
+        pids: &mut HashSet<i32>,
+    ) {
+        if depth > MAX_DEPTH || *visited >= MAX_ELEMENTS {
+            return;
+        }
+        *visited += 1;
+
+        let mut pid = 0;
+        let result = unsafe { AXUIElementGetPid(element.as_concrete_TypeRef(), &mut pid) };
+        if result == 0 && pid > 0 && pid != editor_pid {
+            pids.insert(pid);
+        }
+
+        let Ok(children) = element.children() else {
+            return;
+        };
+        for child in children.iter() {
+            visit(&child, editor_pid, depth + 1, visited, pids);
+            if *visited >= MAX_ELEMENTS {
+                break;
+            }
+        }
+    }
+
+    let mut pids = HashSet::new();
+    let mut visited = 0;
+    visit(window, editor_pid, 0, &mut visited, &mut pids);
+    let mut pids = pids.into_iter().collect::<Vec<_>>();
+    pids.sort_unstable();
+    pids
 }
 
 /// Close a specific window by CGWindowID

--- a/src-tauri/src/ax_observer.rs
+++ b/src-tauri/src/ax_observer.rs
@@ -10,6 +10,8 @@ use std::collections::HashMap;
 use std::ffi::c_void;
 use std::ptr;
 use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
 
 // Accessibility framework types
@@ -48,6 +50,15 @@ const K_AX_TITLE_CHANGED: &str = "AXTitleChanged";
 
 // Error codes
 const K_AX_ERROR_SUCCESS: i32 = 0;
+const WORKSPACE_STATE_REFRESH_DELAY_MS: u64 = 200;
+
+fn request_registry_refresh(source: &'static str) {
+    crate::window_registry::request_refresh(source);
+    thread::spawn(|| {
+        thread::sleep(Duration::from_millis(WORKSPACE_STATE_REFRESH_DELAY_MS));
+        crate::window_registry::request_refresh("ax-event-retry");
+    });
+}
 
 // Wrapper types that implement Send + Sync for raw pointers
 // These are safe because we only access them from the main thread (via CFRunLoop)
@@ -142,13 +153,13 @@ extern "C" fn ax_observer_callback(
                         observer::cancel_pending_other_event();
                         // Emit window-focus-changed event
                         let _ = window.emit("window-focus-changed", ());
+                        request_registry_refresh("ax-focus-event");
                     }
                 }
                 K_AX_WINDOW_CREATED | K_AX_UI_ELEMENT_DESTROYED | K_AX_TITLE_CHANGED => {
                     // Delegate to the registry — it debounces via snapshot diff
                     // and only emits "windows:snapshot" when something actually changed.
-                    let _ = window;
-                    crate::window_registry::request_refresh("ax-event");
+                    request_registry_refresh("ax-event");
                 }
                 _ => {}
             }

--- a/src-tauri/src/cursor_ipc.rs
+++ b/src-tauri/src/cursor_ipc.rs
@@ -1,0 +1,315 @@
+use crate::editor_model::EditorSession;
+use serde_json::Value;
+use std::fs;
+use std::io::{self, Read, Write};
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+const REGULAR_MESSAGE: u8 = 1;
+const RESPONSE_INITIALIZE: i64 = 200;
+const RESPONSE_SUCCESS: i64 = 201;
+const RESPONSE_ERROR: i64 = 202;
+const RESPONSE_ERROR_OBJECT: i64 = 203;
+const SOCKET_TIMEOUT: Duration = Duration::from_millis(750);
+
+pub fn discover_sessions() -> Result<Vec<EditorSession>, String> {
+    let mut last_error = None;
+    for socket_path in cursor_socket_candidates()? {
+        match read_sessions_from_socket(&socket_path) {
+            Ok(sessions) => return Ok(sessions),
+            Err(error) => last_error = Some(format!("{}: {}", socket_path.display(), error)),
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| "Cursor main socket was not found".to_string()))
+}
+
+fn cursor_socket_candidates() -> Result<Vec<PathBuf>, String> {
+    let data_dir = dirs::home_dir()
+        .ok_or_else(|| "Home directory was not found".to_string())?
+        .join("Library/Application Support/Cursor");
+    let entries = fs::read_dir(data_dir).map_err(|error| error.to_string())?;
+    let mut sockets = entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            let name = path.file_name()?.to_str()?;
+            name.ends_with("-main.sock").then_some(path)
+        })
+        .collect::<Vec<_>>();
+
+    sockets.sort_by_key(|path| {
+        fs::metadata(path)
+            .and_then(|metadata| metadata.modified())
+            .ok()
+    });
+    sockets.reverse();
+    Ok(sockets)
+}
+
+fn read_sessions_from_socket(socket_path: &Path) -> Result<Vec<EditorSession>, String> {
+    let mut stream = UnixStream::connect(socket_path).map_err(|error| error.to_string())?;
+    stream
+        .set_read_timeout(Some(SOCKET_TIMEOUT))
+        .map_err(|error| error.to_string())?;
+    stream
+        .set_write_timeout(Some(SOCKET_TIMEOUT))
+        .map_err(|error| error.to_string())?;
+
+    write_regular_message(&mut stream, 1, &encode_string("main"))
+        .map_err(|error| error.to_string())?;
+
+    loop {
+        let payload = read_regular_message(&mut stream).map_err(|error| error.to_string())?;
+        let (header, _) = decode_message(&payload).map_err(|error| error.to_string())?;
+        if header.first().and_then(Value::as_i64) == Some(RESPONSE_INITIALIZE) {
+            break;
+        }
+    }
+
+    let mut request = encode_array(&[
+        EncodedValue::Int(100),
+        EncodedValue::Int(0),
+        EncodedValue::String("diagnostics"),
+        EncodedValue::String("getMainDiagnostics"),
+    ]);
+    request.extend(encode_array(&[]));
+    write_regular_message(&mut stream, 2, &request).map_err(|error| error.to_string())?;
+
+    loop {
+        let payload = read_regular_message(&mut stream).map_err(|error| error.to_string())?;
+        let (header, body) = decode_message(&payload).map_err(|error| error.to_string())?;
+        let response_type = header.first().and_then(Value::as_i64);
+        let request_id = header.get(1).and_then(Value::as_i64);
+        if request_id != Some(0) {
+            continue;
+        }
+        match response_type {
+            Some(RESPONSE_SUCCESS) => return parse_sessions(&body),
+            Some(RESPONSE_ERROR) | Some(RESPONSE_ERROR_OBJECT) => {
+                return Err(format!("Cursor diagnostics failed: {}", body));
+            }
+            _ => {}
+        }
+    }
+}
+
+fn parse_sessions(diagnostics: &Value) -> Result<Vec<EditorSession>, String> {
+    let windows = diagnostics
+        .get("windows")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "Cursor diagnostics did not contain windows".to_string())?;
+    let mut sessions = Vec::new();
+
+    for window in windows {
+        let Some(window_id) = window.get("id").and_then(Value::as_i64) else {
+            continue;
+        };
+        let Some(renderer_pid) = window.get("pid").and_then(Value::as_i64) else {
+            continue;
+        };
+        let title = window
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let path = window
+            .get("folderURIs")
+            .and_then(Value::as_array)
+            .filter(|folder_uris| folder_uris.len() == 1)
+            .and_then(|folder_uris| folder_uris[0].get("fsPath"))
+            .and_then(Value::as_str)
+            .map(PathBuf::from);
+
+        sessions.push(EditorSession {
+            session_id: window_id.to_string(),
+            renderer_pid: renderer_pid as i32,
+            title,
+            path,
+        });
+    }
+
+    Ok(sessions)
+}
+
+fn write_regular_message(stream: &mut UnixStream, id: u32, payload: &[u8]) -> io::Result<()> {
+    let mut header = [0u8; 13];
+    header[0] = REGULAR_MESSAGE;
+    header[1..5].copy_from_slice(&id.to_be_bytes());
+    header[9..13].copy_from_slice(&(payload.len() as u32).to_be_bytes());
+    stream.write_all(&header)?;
+    stream.write_all(payload)
+}
+
+fn read_regular_message(stream: &mut UnixStream) -> io::Result<Vec<u8>> {
+    loop {
+        let mut header = [0u8; 13];
+        stream.read_exact(&mut header)?;
+        let payload_len = u32::from_be_bytes(header[9..13].try_into().unwrap()) as usize;
+        let mut payload = vec![0; payload_len];
+        stream.read_exact(&mut payload)?;
+        if header[0] == REGULAR_MESSAGE {
+            return Ok(payload);
+        }
+    }
+}
+
+enum EncodedValue<'a> {
+    Int(u32),
+    String(&'a str),
+}
+
+fn encode_string(value: &str) -> Vec<u8> {
+    let mut encoded = vec![1];
+    write_vql(&mut encoded, value.len() as u32);
+    encoded.extend(value.as_bytes());
+    encoded
+}
+
+fn encode_array(values: &[EncodedValue<'_>]) -> Vec<u8> {
+    let mut encoded = vec![4];
+    write_vql(&mut encoded, values.len() as u32);
+    for value in values {
+        match value {
+            EncodedValue::Int(value) => {
+                encoded.push(6);
+                write_vql(&mut encoded, *value);
+            }
+            EncodedValue::String(value) => encoded.extend(encode_string(value)),
+        }
+    }
+    encoded
+}
+
+fn write_vql(buffer: &mut Vec<u8>, mut value: u32) {
+    loop {
+        let mut byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value > 0 {
+            byte |= 0x80;
+        }
+        buffer.push(byte);
+        if value == 0 {
+            return;
+        }
+    }
+}
+
+fn read_vql(buffer: &[u8], offset: &mut usize) -> Result<u32, &'static str> {
+    let mut value = 0u32;
+    for shift in (0..32).step_by(7) {
+        let byte = *buffer.get(*offset).ok_or("Unexpected end of IPC value")?;
+        *offset += 1;
+        value |= ((byte & 0x7f) as u32) << shift;
+        if byte & 0x80 == 0 {
+            return Ok(value);
+        }
+    }
+    Err("Invalid IPC integer")
+}
+
+fn decode_message(buffer: &[u8]) -> Result<(Vec<Value>, Value), &'static str> {
+    let mut offset = 0;
+    let header = decode_value(buffer, &mut offset)?;
+    let body = decode_value(buffer, &mut offset)?;
+    let header = header
+        .as_array()
+        .cloned()
+        .ok_or("IPC header was not an array")?;
+    Ok((header, body))
+}
+
+fn decode_value(buffer: &[u8], offset: &mut usize) -> Result<Value, &'static str> {
+    let value_type = *buffer.get(*offset).ok_or("Unexpected end of IPC message")?;
+    *offset += 1;
+    match value_type {
+        0 => Ok(Value::Null),
+        1 => {
+            let length = read_vql(buffer, offset)? as usize;
+            let bytes = buffer
+                .get(*offset..*offset + length)
+                .ok_or("Invalid IPC string length")?;
+            *offset += length;
+            Ok(Value::String(
+                std::str::from_utf8(bytes)
+                    .map_err(|_| "Invalid IPC string")?
+                    .to_string(),
+            ))
+        }
+        2 | 3 => {
+            let length = read_vql(buffer, offset)? as usize;
+            *offset = offset
+                .checked_add(length)
+                .filter(|end| *end <= buffer.len())
+                .ok_or("Invalid IPC buffer length")?;
+            Ok(Value::Null)
+        }
+        4 => {
+            let length = read_vql(buffer, offset)? as usize;
+            let mut values = Vec::with_capacity(length);
+            for _ in 0..length {
+                values.push(decode_value(buffer, offset)?);
+            }
+            Ok(Value::Array(values))
+        }
+        5 => {
+            let length = read_vql(buffer, offset)? as usize;
+            let bytes = buffer
+                .get(*offset..*offset + length)
+                .ok_or("Invalid IPC object length")?;
+            *offset += length;
+            serde_json::from_slice(bytes).map_err(|_| "Invalid IPC object")
+        }
+        6 => Ok(Value::from(read_vql(buffer, offset)?)),
+        _ => Err("Unsupported IPC value type"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codec_round_trips_request_values() {
+        let mut encoded = encode_array(&[
+            EncodedValue::Int(100),
+            EncodedValue::Int(0),
+            EncodedValue::String("diagnostics"),
+            EncodedValue::String("getMainDiagnostics"),
+        ]);
+        encoded.push(0);
+
+        let (header, body) = decode_message(&encoded).unwrap();
+        assert_eq!(header[0], 100);
+        assert_eq!(header[2], "diagnostics");
+        assert_eq!(header[3], "getMainDiagnostics");
+        assert!(body.is_null());
+    }
+
+    #[test]
+    fn diagnostics_windows_are_parsed_without_using_array_order() {
+        let diagnostics = serde_json::json!({
+            "windows": [
+                {
+                    "id": 4,
+                    "pid": 9004,
+                    "title": "project",
+                    "folderURIs": [{ "fsPath": "/worktrees/project" }]
+                },
+                {
+                    "id": 1,
+                    "pid": 9001,
+                    "title": "project",
+                    "folderURIs": [{ "fsPath": "/projects/project" }]
+                }
+            ]
+        });
+
+        let sessions = parse_sessions(&diagnostics).unwrap();
+        assert_eq!(sessions[0].renderer_pid, 9004);
+        assert_eq!(sessions[0].path, Some(PathBuf::from("/worktrees/project")));
+        assert_eq!(sessions[1].renderer_pid, 9001);
+        assert_eq!(sessions[1].path, Some(PathBuf::from("/projects/project")));
+    }
+}

--- a/src-tauri/src/editor.rs
+++ b/src-tauri/src/editor.rs
@@ -1,38 +1,26 @@
 use crate::ax_helper;
 use crate::editor_config::{EditorConfig, EDITORS};
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use crate::editor_model::{EditorSession, NativeEditorWindow};
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
+pub use crate::editor_model::{EditorState, EditorWindow, WorkspaceResolution};
+
+type WindowPathCacheKey = (String, u32, String);
+type WorkspacePathOwnerKey = (String, PathBuf);
+
 lazy_static::lazy_static! {
-    /// Editor ID + project name -> full path candidates
-    static ref PROJECT_PATH_CACHE: std::sync::Mutex<HashMap<String, Vec<PathBuf>>> =
-        std::sync::Mutex::new(HashMap::new());
     /// Editor ID + window ID + project name -> full path
-    static ref WINDOW_PATH_CACHE: std::sync::Mutex<HashMap<(String, u32, String), PathBuf>> =
-        std::sync::Mutex::new(HashMap::new());
-    /// エディタIDごとの初期化フラグ
-    static ref CACHE_INITIALIZED: std::sync::Mutex<HashMap<String, bool>> =
+    static ref WINDOW_PATH_CACHE: std::sync::Mutex<HashMap<WindowPathCacheKey, PathBuf>> =
         std::sync::Mutex::new(HashMap::new());
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct EditorWindow {
-    pub id: u32,  // CGWindowID for reliable window identification
-    pub name: String,
-    pub path: String,
-    pub branch: Option<String>,  // Git branch name
-    pub repository_id: Option<String>,
-    pub repository_name: Option<String>,
-    pub bundle_id: String,       // Editor's macOS bundle ID
-    pub editor_name: String,     // Editor display name (e.g. "Visual Studio Code")
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct EditorState {
-    pub is_active: bool,
-    pub windows: Vec<EditorWindow>,
-    pub active_index: Option<usize>,
+#[derive(Default)]
+struct OpenWorkspaceState {
+    is_available: bool,
+    active_path: Option<PathBuf>,
+    all_paths: Vec<PathBuf>,
+    paths_by_name: HashMap<String, Vec<PathBuf>>,
 }
 
 /// Get editor state for any running editor
@@ -98,45 +86,13 @@ pub fn get_editor_state_with_config(config: &EditorConfig) -> EditorState {
         None => return EditorState { is_active, windows: vec![], active_index: None },
     };
 
-    let ax_windows = match ax_helper::get_windows_ax(pid) {
-        Ok(w) => w,
+    let (windows, active_id) = match collect_editor_windows(config, pid) {
+        Ok(result) => result,
         Err(_) => return EditorState { is_active, windows: vec![], active_index: None },
     };
-
-    let mut active_index: Option<usize> = None;
-    let mut windows = Vec::new();
-
-    for (window_id, title, is_frontmost) in ax_windows.iter() {
-        // Filter out temporary/transient windows
-        if title.is_empty() || title == "Untitled" {
-            continue;
-        }
-
-        let name = extract_project_name(title, config);
-
-        let resolved_path = resolve_project_path(&name, config.id, pid, *window_id);
-        let git_root = resolved_path.as_ref().and_then(|path| find_git_root(path));
-        let branch = git_root.as_ref().and_then(|root| get_git_branch(root));
-        let repository = git_root.as_ref().and_then(|root| get_repository_info(root));
-        let path_str = resolved_path
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_default();
-
-        windows.push(EditorWindow {
-            id: *window_id,  // Use CGWindowID for reliable identification
-            name,
-            path: path_str,
-            branch,
-            repository_id: repository.as_ref().map(|(id, _)| id.clone()),
-            repository_name: repository.map(|(_, name)| name),
-            bundle_id: config.bundle_id.to_string(),
-            editor_name: config.display_name.to_string(),
-        });
-
-        if *is_frontmost {
-            active_index = Some(windows.len() - 1);
-        }
-    }
+    let active_index = active_id.and_then(|active_id| {
+        windows.iter().position(|window| window.id == active_id)
+    });
 
     EditorState { is_active, windows, active_index }
 }
@@ -164,137 +120,333 @@ pub fn get_editor_windows_with_config(config: &EditorConfig) -> Vec<EditorWindow
         None => return vec![],
     };
 
-    let ax_windows = match ax_helper::get_windows_ax(pid) {
-        Ok(w) => w,
-        Err(_) => return vec![],
-    };
+    collect_editor_windows(config, pid)
+        .map(|(windows, _)| windows)
+        .unwrap_or_default()
+}
 
-    ax_windows
+fn collect_editor_windows(
+    config: &EditorConfig,
+    pid: i32,
+) -> Result<(Vec<EditorWindow>, Option<u32>), String> {
+    let native_windows = ax_helper::get_native_windows_ax(
+        pid,
+        config.bundle_id,
+        config.id == "cursor",
+    )?;
+    let sessions = if config.id == "cursor" {
+        crate::cursor_ipc::discover_sessions().unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    let session_resolutions = resolve_sessions(&native_windows, &sessions);
+    let workspace_state = if sessions.is_empty() {
+        load_open_workspace_state(config.id)
+    } else {
+        open_workspace_state_from_sessions(&sessions)
+    };
+    let ax_windows = native_windows
         .iter()
-        .filter_map(|(window_id, title, _)| {
-            // Filter out temporary/transient windows
-            if title.is_empty() || title == "Untitled" {
+        .map(|window| (window.id, window.title.clone(), window.is_frontmost))
+        .collect::<Vec<_>>();
+    prepare_window_path_resolution(config, &ax_windows, &workspace_state);
+    let project_window_counts = count_project_windows(config, &ax_windows);
+
+    for (window_id, (path, _)) in &session_resolutions {
+        if let Some(window) = native_windows.iter().find(|window| window.id == *window_id) {
+            let name = extract_project_name(&window.title, config);
+            cache_window_path(config.id, *window_id, &name, path);
+        }
+    }
+
+    let active_id = native_windows
+        .iter()
+        .find(|window| window.is_frontmost)
+        .map(|window| window.id);
+    let windows = native_windows
+        .iter()
+        .filter_map(|window| {
+            if window.title.is_empty() || window.title == "Untitled" {
                 return None;
             }
-
-            let name = extract_project_name(title, config);
-
-            let resolved_path = resolve_project_path(&name, config.id, pid, *window_id);
+            let name = extract_project_name(&window.title, config);
+            let session_resolution = session_resolutions.get(&window.id);
+            let resolved_path = session_resolution
+                .map(|(path, _)| path.clone())
+                .or_else(|| {
+                    resolve_project_path(
+                        &name,
+                        config.id,
+                        pid,
+                        window.id,
+                        project_window_counts.get(&name).copied().unwrap_or(1),
+                        &workspace_state,
+                    )
+                });
+            let resolution = session_resolution
+                .map(|(_, resolution)| *resolution)
+                .or_else(|| resolved_path.as_ref().map(|_| WorkspaceResolution::Inferred))
+                .unwrap_or(WorkspaceResolution::Unresolved);
             let git_root = resolved_path.as_ref().and_then(|path| find_git_root(path));
             let branch = git_root.as_ref().and_then(|root| get_git_branch(root));
             let repository = git_root.as_ref().and_then(|root| get_repository_info(root));
-            let path_str = resolved_path
-                .map(|p| p.to_string_lossy().to_string())
-                .unwrap_or_default();
 
             Some(EditorWindow {
-                id: *window_id,  // Use CGWindowID for reliable identification
+                runtime_id: window.runtime_id.clone(),
+                id: window.id,
                 name,
-                path: path_str,
+                path: resolved_path
+                    .map(|path| path.to_string_lossy().to_string())
+                    .unwrap_or_default(),
                 branch,
                 repository_id: repository.as_ref().map(|(id, _)| id.clone()),
                 repository_name: repository.map(|(_, name)| name),
                 bundle_id: config.bundle_id.to_string(),
                 editor_name: config.display_name.to_string(),
+                resolution,
             })
         })
-        .collect()
+        .collect();
+
+    Ok((windows, active_id))
 }
 
 /// Get windows from ALL running editors
 pub fn get_all_editor_windows() -> Vec<EditorWindow> {
+    get_all_editor_window_snapshot().0
+}
+
+pub fn get_all_editor_window_snapshot() -> (Vec<EditorWindow>, Option<u32>) {
+    let editor_bundle_ids = EDITORS.iter().map(|editor| editor.bundle_id).collect::<Vec<_>>();
+    let frontmost_bundle_id = ax_helper::get_frontmost_editor_bundle_id(&editor_bundle_ids);
     let mut all_windows = Vec::new();
+    let mut active_id = None;
     for editor in EDITORS {
-        all_windows.extend(get_editor_windows_with_config(editor));
+        let Some(pid) = ax_helper::get_pid_by_bundle_id(editor.bundle_id) else {
+            continue;
+        };
+        let Ok((windows, editor_active_id)) = collect_editor_windows(editor, pid) else {
+            continue;
+        };
+        if frontmost_bundle_id.as_deref() == Some(editor.bundle_id) {
+            active_id = editor_active_id;
+        }
+        all_windows.extend(windows);
     }
-    all_windows
+    (all_windows, active_id)
 }
 
-/// Return the CGWindowID of the frontmost editor's focused window, if any.
-/// Returns None when no supported editor is frontmost, or the frontmost editor
-/// has no focused non-transient window.
-pub fn get_active_window_id() -> Option<u32> {
-    let editor_bundle_ids: Vec<&str> = EDITORS.iter().map(|e| e.bundle_id).collect();
-    let frontmost_bid = ax_helper::get_frontmost_editor_bundle_id(&editor_bundle_ids)?;
-    let config = crate::editor_config::get_editor_by_bundle_id(&frontmost_bid)?;
-    let pid = ax_helper::get_pid_by_bundle_id(config.bundle_id)?;
-    let ax_windows = ax_helper::get_windows_ax(pid).ok()?;
-    ax_windows
-        .iter()
-        .find(|(_, title, is_frontmost)| {
-            *is_frontmost && !title.is_empty() && title != "Untitled"
-        })
-        .map(|(id, _, _)| *id)
-}
-
-/// Invalidate the workspace.json / project path cache for a specific editor.
-///
-/// Called by the registry when an editor's PID changes (restart), since a
-/// restart can mean workspace.json files changed while we weren't looking.
+/// Invalidate window path assignments when an editor process changes.
 pub fn invalidate_path_cache_for_editor(editor_id: &str) {
-    if let Ok(mut initialized) = CACHE_INITIALIZED.lock() {
-        initialized.remove(editor_id);
-    }
-    if let Ok(mut cache) = PROJECT_PATH_CACHE.lock() {
-        let prefix = format!("{}:", editor_id);
-        cache.retain(|key, _| !key.starts_with(&prefix));
-    }
     if let Ok(mut cache) = WINDOW_PATH_CACHE.lock() {
         cache.retain(|(cached_editor_id, _, _), _| cached_editor_id != editor_id);
     }
 }
 
-/// エディタIDからworkspaceStorageディレクトリのパスを返す
-fn get_workspace_storage_dir(editor_id: &str) -> Option<PathBuf> {
+fn resolve_sessions(
+    native_windows: &[NativeEditorWindow],
+    sessions: &[EditorSession],
+) -> HashMap<u32, (PathBuf, WorkspaceResolution)> {
+    let mut resolutions = HashMap::new();
+    let mut assigned_sessions = HashSet::new();
+
+    for window in native_windows {
+        let matches = sessions
+            .iter()
+            .filter(|session| {
+                session.path.is_some() && window.renderer_pids.contains(&session.renderer_pid)
+            })
+            .collect::<Vec<_>>();
+        if matches.len() == 1 {
+            let session = matches[0];
+            resolutions.insert(
+                window.id,
+                (session.path.clone().unwrap(), WorkspaceResolution::Exact),
+            );
+            assigned_sessions.insert(session.session_id.clone());
+        }
+    }
+
+    let mut windows_by_creation = native_windows.iter().collect::<Vec<_>>();
+    windows_by_creation.sort_by_key(|window| window.id);
+    let mut sessions_by_creation = sessions.iter().collect::<Vec<_>>();
+    sessions_by_creation.sort_by_key(|session| {
+        session.session_id.parse::<u32>().unwrap_or(u32::MAX)
+    });
+    let creation_sequence_matches = windows_by_creation.len() == sessions_by_creation.len()
+        && windows_by_creation
+            .iter()
+            .zip(&sessions_by_creation)
+            .all(|(window, session)| window.title == session.title);
+    if creation_sequence_matches {
+        for (window, session) in windows_by_creation.iter().zip(&sessions_by_creation) {
+            if resolutions.contains_key(&window.id)
+                || assigned_sessions.contains(&session.session_id)
+            {
+                continue;
+            }
+            if let Some(path) = &session.path {
+                resolutions.insert(
+                    window.id,
+                    (path.clone(), WorkspaceResolution::Inferred),
+                );
+                assigned_sessions.insert(session.session_id.clone());
+            }
+        }
+    }
+
+    for window in native_windows {
+        if resolutions.contains_key(&window.id) {
+            continue;
+        }
+        let same_title_windows = native_windows
+            .iter()
+            .filter(|candidate| {
+                !resolutions.contains_key(&candidate.id) && candidate.title == window.title
+            })
+            .count();
+        let matching_sessions = sessions
+            .iter()
+            .filter(|session| {
+                session.path.is_some()
+                    && !assigned_sessions.contains(&session.session_id)
+                    && session.title == window.title
+            })
+            .collect::<Vec<_>>();
+        if same_title_windows == 1 && matching_sessions.len() == 1 {
+            let session = matching_sessions[0];
+            resolutions.insert(
+                window.id,
+                (session.path.clone().unwrap(), WorkspaceResolution::Inferred),
+            );
+            assigned_sessions.insert(session.session_id.clone());
+        }
+    }
+
+    resolutions
+}
+
+fn open_workspace_state_from_sessions(sessions: &[EditorSession]) -> OpenWorkspaceState {
+    let mut all_paths = Vec::new();
+    let mut paths_by_name = HashMap::new();
+
+    for session in sessions {
+        let Some(path) = &session.path else {
+            continue;
+        };
+        if !path.exists() {
+            continue;
+        }
+        add_unique_path(&mut all_paths, path.clone());
+        if let Some(name) = path.file_name().and_then(|name| name.to_str()) {
+            add_named_workspace_path(&mut paths_by_name, name, path);
+        }
+        add_named_workspace_path(&mut paths_by_name, &session.title, path);
+    }
+
+    OpenWorkspaceState {
+        is_available: true,
+        active_path: None,
+        all_paths,
+        paths_by_name,
+    }
+}
+
+fn get_editor_user_dir(editor_id: &str) -> Option<PathBuf> {
     let home = dirs::home_dir()?;
     let subdir = match editor_id {
         "cursor" => "Cursor",
         "vscode" => "Code",
-        _ => return None, // Zed等は非対応
+        _ => return None,
     };
-    Some(home.join("Library/Application Support").join(subdir).join("User/workspaceStorage"))
+    Some(
+        home.join("Library/Application Support")
+            .join(subdir)
+            .join("User"),
+    )
 }
 
-fn add_workspace_path(map: &mut HashMap<String, Vec<PathBuf>>, path: PathBuf) {
-    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
-        return;
-    };
-    let paths = map.entry(name.to_string()).or_default();
+fn get_global_storage_file(editor_id: &str) -> Option<PathBuf> {
+    Some(get_editor_user_dir(editor_id)?.join("globalStorage/storage.json"))
+}
+
+fn add_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
     if !paths.contains(&path) {
         paths.push(path);
     }
 }
 
-/// Read workspace.json files and map project names to full path candidates
-fn load_workspace_paths(editor_id: &str) -> HashMap<String, Vec<PathBuf>> {
-    let mut map = HashMap::new();
-    let storage_dir = match get_workspace_storage_dir(editor_id) {
-        Some(d) => d,
-        None => return map,
+fn add_named_workspace_path(map: &mut HashMap<String, Vec<PathBuf>>, name: &str, path: &Path) {
+    let paths = map.entry(name.to_string()).or_default();
+    if !paths.iter().any(|candidate| candidate == path) {
+        paths.push(path.to_path_buf());
+    }
+}
+
+fn folder_path(value: &serde_json::Value) -> Option<PathBuf> {
+    let folder = value.get("folder")?.as_str()?;
+    let path = folder.strip_prefix("file://").unwrap_or(folder);
+    Some(PathBuf::from(percent_decode(path)))
+}
+
+fn parse_open_workspace_paths(json: &serde_json::Value) -> (Option<PathBuf>, Vec<PathBuf>) {
+    let windows_state = match json.get("windowsState") {
+        Some(state) => state,
+        None => return (None, Vec::new()),
     };
-    let entries = match std::fs::read_dir(&storage_dir) {
-        Ok(e) => e,
-        Err(_) => return map,
-    };
-    for entry in entries.flatten() {
-        let ws_json = entry.path().join("workspace.json");
-        if let Ok(content) = std::fs::read_to_string(&ws_json) {
-            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
-                if let Some(folder) = json.get("folder").and_then(|v| v.as_str()) {
-                    let path_str = folder
-                        .strip_prefix("file://")
-                        .unwrap_or(folder);
-                    // URLデコード（スペースなどの%エンコード対応）
-                    let decoded = percent_decode(path_str);
-                    let path = PathBuf::from(&decoded);
-                    if path.exists() {
-                        add_workspace_path(&mut map, path);
-                    }
-                }
+    let active_path = windows_state.get("lastActiveWindow").and_then(folder_path);
+    let mut all_paths = Vec::new();
+
+    if let Some(opened_windows) = windows_state
+        .get("openedWindows")
+        .and_then(|value| value.as_array())
+    {
+        for window in opened_windows {
+            if let Some(path) = folder_path(window) {
+                add_unique_path(&mut all_paths, path);
             }
         }
     }
-    map
+    (active_path, all_paths)
+}
+
+fn load_open_workspace_state(editor_id: &str) -> OpenWorkspaceState {
+    let Some(storage_file) = get_global_storage_file(editor_id) else {
+        return OpenWorkspaceState::default();
+    };
+    let empty_state = || OpenWorkspaceState {
+        is_available: true,
+        ..OpenWorkspaceState::default()
+    };
+    let Ok(content) = std::fs::read_to_string(storage_file) else {
+        return empty_state();
+    };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return empty_state();
+    };
+    let (active_path, all_paths) = parse_open_workspace_paths(&json);
+    let all_paths: Vec<PathBuf> = all_paths.into_iter().filter(|path| path.exists()).collect();
+    let active_path = active_path.filter(|path| all_paths.contains(path));
+    let mut paths_by_name = HashMap::new();
+
+    for path in &all_paths {
+        if let Some(name) = path.file_name().and_then(|name| name.to_str()) {
+            add_named_workspace_path(&mut paths_by_name, name, path);
+        }
+        if let Some((_, repository_name)) = find_git_root(path)
+            .as_ref()
+            .and_then(|root| get_repository_info(root))
+        {
+            add_named_workspace_path(&mut paths_by_name, &repository_name, path);
+        }
+    }
+
+    OpenWorkspaceState {
+        is_available: true,
+        active_path,
+        all_paths,
+        paths_by_name,
+    }
 }
 
 /// 簡易パーセントデコード（%XX → バイト変換）
@@ -322,10 +474,6 @@ fn percent_decode(input: &str) -> String {
     String::from_utf8(bytes).unwrap_or_else(|_| input.to_string())
 }
 
-fn workspace_cache_key(editor_id: &str, project_name: &str) -> String {
-    format!("{}:{}", editor_id, project_name)
-}
-
 fn cache_window_path(editor_id: &str, window_id: u32, project_name: &str, path: &Path) {
     if let Ok(mut cache) = WINDOW_PATH_CACHE.lock() {
         cache.insert(
@@ -333,39 +481,6 @@ fn cache_window_path(editor_id: &str, window_id: u32, project_name: &str, path: 
             path.to_path_buf(),
         );
     }
-}
-
-fn cache_project_path(editor_id: &str, project_name: &str, path: &Path) {
-    if let Ok(mut cache) = PROJECT_PATH_CACHE.lock() {
-        let paths = cache
-            .entry(workspace_cache_key(editor_id, project_name))
-            .or_default();
-        if !paths.iter().any(|cached_path| cached_path == path) {
-            paths.push(path.to_path_buf());
-        }
-    }
-}
-
-fn ensure_workspace_paths_loaded(editor_id: &str) -> Option<()> {
-    let mut initialized = CACHE_INITIALIZED.lock().ok()?;
-    if initialized.get(editor_id).copied().unwrap_or(false) {
-        return Some(());
-    }
-
-    let paths = load_workspace_paths(editor_id);
-    let mut cache = PROJECT_PATH_CACHE.lock().ok()?;
-    for (name, candidate_paths) in paths {
-        let cached_paths = cache
-            .entry(workspace_cache_key(editor_id, &name))
-            .or_default();
-        for path in candidate_paths {
-            if !cached_paths.contains(&path) {
-                cached_paths.push(path);
-            }
-        }
-    }
-    initialized.insert(editor_id.to_string(), true);
-    Some(())
 }
 
 fn workspace_path_for_document(candidates: &[PathBuf], document_path: &Path) -> Option<PathBuf> {
@@ -376,72 +491,159 @@ fn workspace_path_for_document(candidates: &[PathBuf], document_path: &Path) -> 
         .cloned()
 }
 
+fn count_project_windows(
+    config: &EditorConfig,
+    ax_windows: &[(u32, String, bool)],
+) -> HashMap<String, usize> {
+    let mut counts = HashMap::new();
+    for (_, title, _) in ax_windows {
+        if title.is_empty() || title == "Untitled" {
+            continue;
+        }
+        *counts.entry(extract_project_name(title, config)).or_default() += 1;
+    }
+    counts
+}
+
+fn single_unassigned_workspace_path(
+    candidates: &[PathBuf],
+    assigned_paths: &[PathBuf],
+    unassigned_window_count: usize,
+) -> Option<PathBuf> {
+    if unassigned_window_count != 1 {
+        return None;
+    }
+    let mut unassigned = candidates
+        .iter()
+        .filter(|candidate| !assigned_paths.contains(candidate));
+    let path = unassigned.next()?.clone();
+    unassigned.next().is_none().then_some(path)
+}
+
+fn prepare_window_path_resolution(
+    config: &EditorConfig,
+    ax_windows: &[(u32, String, bool)],
+    workspace_state: &OpenWorkspaceState,
+) {
+    let active_window = workspace_state
+        .active_path
+        .as_ref()
+        .and_then(|active_path| {
+            let (window_id, title, _) = ax_windows.iter().find(|(_, title, is_frontmost)| {
+                *is_frontmost && !title.is_empty() && title != "Untitled"
+            })?;
+            let project_name = extract_project_name(title, config);
+            let is_candidate = workspace_state
+                .paths_by_name
+                .get(&project_name)
+                .is_some_and(|paths| paths.contains(active_path));
+            is_candidate.then(|| (*window_id, project_name, active_path.clone()))
+        });
+
+    let mut cache = match WINDOW_PATH_CACHE.lock() {
+        Ok(cache) => cache,
+        Err(_) => return,
+    };
+    cache.retain(|(editor_id, window_id, project_name), path| {
+        if editor_id != config.id {
+            return true;
+        }
+        let window_exists = ax_windows.iter().any(|(id, _, _)| id == window_id);
+        let path_is_open = !workspace_state.is_available
+            || workspace_state
+                .paths_by_name
+                .get(project_name)
+                .is_some_and(|paths| paths.contains(path));
+        window_exists && path_is_open
+    });
+
+    let active_key = active_window.map(|(window_id, project_name, active_path)| {
+        let key = (config.id.to_string(), window_id, project_name);
+        cache.insert(key.clone(), active_path);
+        key
+    });
+
+    let mut path_owners: HashMap<WorkspacePathOwnerKey, (WindowPathCacheKey, bool)> =
+        HashMap::new();
+    let mut duplicate_keys = Vec::new();
+    for (key, path) in cache.iter().filter(|(key, _)| key.0 == config.id) {
+        let owner_key = (key.2.clone(), path.clone());
+        let is_active = active_key.as_ref() == Some(key);
+        if let Some((existing_key, existing_is_active)) = path_owners.get(&owner_key) {
+            if is_active && !existing_is_active {
+                duplicate_keys.push(existing_key.clone());
+                path_owners.insert(owner_key, (key.clone(), true));
+            } else {
+                duplicate_keys.push(key.clone());
+            }
+        } else {
+            path_owners.insert(owner_key, (key.clone(), is_active));
+        }
+    }
+    for key in duplicate_keys {
+        cache.remove(&key);
+    }
+}
+
 /// Resolve a full path from the project name and window metadata
 fn resolve_project_path(
     project_name: &str,
     editor_id: &str,
     pid: i32,
     window_id: u32,
+    project_window_count: usize,
+    workspace_state: &OpenWorkspaceState,
 ) -> Option<PathBuf> {
     let document_path = ax_helper::get_document_path(pid, window_id).map(PathBuf::from);
-    ensure_workspace_paths_loaded(editor_id)?;
-
-    let project_paths = {
-        let cache = PROJECT_PATH_CACHE.lock().ok()?;
-        cache
-            .get(&workspace_cache_key(editor_id, project_name))
-            .cloned()
-            .unwrap_or_default()
-    };
 
     if let Some(document_path) = document_path {
         // Use the containing workspace to distinguish same-named worktrees and submodules
-        if let Some(workspace_path) = workspace_path_for_document(&project_paths, &document_path) {
+        if let Some(workspace_path) =
+            workspace_path_for_document(&workspace_state.all_paths, &document_path)
+        {
             cache_window_path(editor_id, window_id, project_name, &workspace_path);
             return Some(workspace_path);
         }
         if let Some(git_root) = find_git_root(&document_path) {
             cache_window_path(editor_id, window_id, project_name, &git_root);
-            cache_project_path(editor_id, project_name, &git_root);
             return Some(git_root);
         }
     }
 
     let window_cache_key = (editor_id.to_string(), window_id, project_name.to_string());
-    {
-        let cache = WINDOW_PATH_CACHE.lock().ok()?;
-        if let Some(path) = cache.get(&window_cache_key) {
+    let candidates = workspace_state
+        .paths_by_name
+        .get(project_name)
+        .cloned()
+        .unwrap_or_default();
+    let mut cache = WINDOW_PATH_CACHE.lock().ok()?;
+    if let Some(path) = cache.get(&window_cache_key) {
+        if !workspace_state.is_available || candidates.contains(path) {
             return Some(path.clone());
         }
+        cache.remove(&window_cache_key);
     }
 
-    if project_paths.len() == 1 {
-        let path = project_paths[0].clone();
-        cache_window_path(editor_id, window_id, project_name, &path);
-        return Some(path);
-    }
-
-    {
-        let parent_paths: Vec<PathBuf> = {
-            let cache = PROJECT_PATH_CACHE.lock().ok()?;
-            let prefix = format!("{}:", editor_id);
-            cache
-                .iter()
-                .filter(|(key, _)| key.starts_with(&prefix))
-                .flat_map(|(_, paths)| paths.iter().cloned())
-                .collect()
-        };
-        for parent_path in &parent_paths {
-            let candidate = parent_path.join(project_name);
-            if candidate.is_dir() && candidate.join(".git").exists() {
-                cache_window_path(editor_id, window_id, project_name, &candidate);
-                cache_project_path(editor_id, project_name, &candidate);
-                return Some(candidate);
-            }
-        }
-    }
-
-    None
+    let assigned_paths: Vec<PathBuf> = cache
+        .iter()
+        .filter(
+            |((cached_editor_id, cached_window_id, cached_project_name), path)| {
+                cached_editor_id == editor_id
+                    && *cached_window_id != window_id
+                    && cached_project_name == project_name
+                    && candidates.contains(path)
+            },
+        )
+        .map(|(_, path)| path.clone())
+        .collect();
+    let unassigned_window_count = project_window_count.saturating_sub(assigned_paths.len());
+    let path = single_unassigned_workspace_path(
+        &candidates,
+        &assigned_paths,
+        unassigned_window_count,
+    )?;
+    cache.insert(window_cache_key, path.clone());
+    Some(path)
 }
 
 /// Extract project name from editor window title
@@ -624,6 +826,57 @@ pub fn close_editor_window(bundle_id: &str, window_id: u32) -> Result<(), String
 mod tests {
     use super::*;
     use std::fs;
+
+    fn native_window(id: u32, title: &str) -> NativeEditorWindow {
+        NativeEditorWindow::new("cursor", 10, id, title.to_string(), false, Vec::new())
+    }
+
+    fn editor_session(id: u32, title: &str, path: Option<&str>) -> EditorSession {
+        EditorSession {
+            session_id: id.to_string(),
+            renderer_pid: 1000 + id as i32,
+            title: title.to_string(),
+            path: path.map(PathBuf::from),
+        }
+    }
+
+    #[test]
+    fn cursor_sessions_are_resolved_by_creation_ids_not_input_order() {
+        let windows = vec![
+            native_window(400, "project"),
+            native_window(100, "project"),
+            native_window(300, "Cursor Agents"),
+            native_window(200, "api"),
+        ];
+        let sessions = vec![
+            editor_session(4, "project", Some("/worktrees/project")),
+            editor_session(2, "api", Some("/projects/api")),
+            editor_session(1, "project", Some("/projects/project")),
+            editor_session(3, "Cursor Agents", None),
+        ];
+
+        let resolved = resolve_sessions(&windows, &sessions);
+
+        assert_eq!(resolved[&100].0, PathBuf::from("/projects/project"));
+        assert_eq!(resolved[&200].0, PathBuf::from("/projects/api"));
+        assert_eq!(resolved[&400].0, PathBuf::from("/worktrees/project"));
+    }
+
+    #[test]
+    fn duplicate_titles_remain_unresolved_when_creation_sequence_disagrees() {
+        let windows = vec![
+            native_window(100, "project"),
+            native_window(200, "project"),
+        ];
+        let sessions = vec![
+            editor_session(1, "project", Some("/projects/project")),
+            editor_session(2, "different", Some("/worktrees/project")),
+        ];
+
+        let resolved = resolve_sessions(&windows, &sessions);
+
+        assert!(resolved.is_empty());
+    }
 
     #[test]
     fn find_git_root_in_repo() {
@@ -817,32 +1070,135 @@ mod tests {
     }
 
     #[test]
-    fn load_workspace_paths_unsupported_editor() {
-        let result = load_workspace_paths("zed");
-        assert!(result.is_empty());
+    fn unsupported_editor_has_no_global_storage_file() {
+        assert!(get_global_storage_file("zed").is_none());
     }
 
     #[test]
-    fn get_workspace_storage_dir_known_editors() {
-        let cursor_dir = get_workspace_storage_dir("cursor");
-        assert!(cursor_dir.is_some());
-        assert!(cursor_dir.unwrap().to_string_lossy().contains("Cursor"));
+    fn global_storage_file_is_resolved_for_known_editors() {
+        let cursor_file = get_global_storage_file("cursor").unwrap();
+        assert!(cursor_file.to_string_lossy().contains("Cursor"));
+        assert!(cursor_file.ends_with("globalStorage/storage.json"));
 
-        let vscode_dir = get_workspace_storage_dir("vscode");
-        assert!(vscode_dir.is_some());
-        assert!(vscode_dir.unwrap().to_string_lossy().contains("Code"));
-
-        let zed_dir = get_workspace_storage_dir("zed");
-        assert!(zed_dir.is_none());
+        let vscode_file = get_global_storage_file("vscode").unwrap();
+        assert!(vscode_file.to_string_lossy().contains("Code"));
+        assert!(vscode_file.ends_with("globalStorage/storage.json"));
     }
 
     #[test]
-    fn workspace_paths_keep_same_named_worktrees() {
-        let mut paths = HashMap::new();
-        add_workspace_path(&mut paths, PathBuf::from("/worktrees/one/project"));
-        add_workspace_path(&mut paths, PathBuf::from("/worktrees/two/project"));
+    fn current_open_workspace_paths_are_parsed() {
+        let json = serde_json::json!({
+            "windowsState": {
+                "lastActiveWindow": {
+                    "folder": "file:///worktrees/two/sample%20project"
+                },
+                "openedWindows": [
+                    { "folder": "file:///worktrees/one/sample%20project" },
+                    { "backupPath": "/tmp/empty-window" },
+                    { "folder": "file:///worktrees/two/sample%20project" }
+                ]
+            }
+        });
 
-        assert_eq!(paths.get("project").unwrap().len(), 2);
+        let (active_path, all_paths) = parse_open_workspace_paths(&json);
+
+        assert_eq!(
+            active_path,
+            Some(PathBuf::from("/worktrees/two/sample project"))
+        );
+        assert_eq!(
+            all_paths,
+            vec![
+                PathBuf::from("/worktrees/one/sample project"),
+                PathBuf::from("/worktrees/two/sample project"),
+            ]
+        );
+    }
+
+    #[test]
+    fn active_workspace_is_not_treated_as_open_until_opened_windows_updates() {
+        let json = serde_json::json!({
+            "windowsState": {
+                "lastActiveWindow": { "folder": "file:///projects/active" },
+                "openedWindows": []
+            }
+        });
+
+        let (active_path, all_paths) = parse_open_workspace_paths(&json);
+
+        assert_eq!(active_path, Some(PathBuf::from("/projects/active")));
+        assert!(all_paths.is_empty());
+    }
+
+    #[test]
+    fn single_remaining_workspace_is_selected() {
+        let candidates = vec![
+            PathBuf::from("/worktrees/one/project"),
+            PathBuf::from("/worktrees/two/project"),
+        ];
+        let assigned = vec![PathBuf::from("/worktrees/one/project")];
+
+        assert_eq!(
+            single_unassigned_workspace_path(&candidates, &assigned, 1),
+            Some(PathBuf::from("/worktrees/two/project"))
+        );
+    }
+
+    #[test]
+    fn ambiguous_workspaces_are_not_guessed() {
+        let candidates = vec![
+            PathBuf::from("/worktrees/one/project"),
+            PathBuf::from("/worktrees/two/project"),
+        ];
+
+        assert_eq!(single_unassigned_workspace_path(&candidates, &[], 2), None);
+    }
+
+    #[test]
+    fn sole_candidate_is_not_assigned_to_one_of_multiple_windows() {
+        let candidates = vec![PathBuf::from("/projects/project")];
+
+        assert_eq!(single_unassigned_workspace_path(&candidates, &[], 2), None);
+    }
+
+    #[test]
+    fn active_window_replaces_duplicate_cached_assignment() {
+        let config = EditorConfig {
+            id: "cache-test",
+            display_name: "Sample Editor",
+            bundle_id: "com.example.editor",
+            app_name: "Sample Editor",
+        };
+        let first_path = PathBuf::from("/worktrees/one/project");
+        let second_path = PathBuf::from("/worktrees/two/project");
+        cache_window_path(config.id, 1, "project", &first_path);
+        cache_window_path(config.id, 2, "project", &first_path);
+
+        let workspace_state = OpenWorkspaceState {
+            is_available: true,
+            active_path: Some(second_path.clone()),
+            all_paths: vec![first_path.clone(), second_path.clone()],
+            paths_by_name: HashMap::from([(
+                "project".to_string(),
+                vec![first_path.clone(), second_path.clone()],
+            )]),
+        };
+        let windows = vec![
+            (1, "project — Sample Editor".to_string(), false),
+            (2, "project — Sample Editor".to_string(), true),
+        ];
+
+        prepare_window_path_resolution(&config, &windows, &workspace_state);
+
+        let cache = WINDOW_PATH_CACHE.lock().unwrap();
+        assert_eq!(
+            cache.get(&(config.id.to_string(), 1, "project".to_string())),
+            Some(&first_path)
+        );
+        assert_eq!(
+            cache.get(&(config.id.to_string(), 2, "project".to_string())),
+            Some(&second_path)
+        );
     }
 
     #[test]

--- a/src-tauri/src/editor_model.rs
+++ b/src-tauri/src/editor_model.rs
@@ -1,0 +1,67 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone)]
+pub struct NativeEditorWindow {
+    pub runtime_id: String,
+    pub id: u32,
+    pub title: String,
+    pub is_frontmost: bool,
+    pub renderer_pids: Vec<i32>,
+}
+
+impl NativeEditorWindow {
+    pub fn new(
+        bundle_id: &str,
+        editor_pid: i32,
+        id: u32,
+        title: String,
+        is_frontmost: bool,
+        renderer_pids: Vec<i32>,
+    ) -> Self {
+        Self {
+            runtime_id: format!("{}:{}:{}", bundle_id, editor_pid, id),
+            id,
+            title,
+            is_frontmost,
+            renderer_pids,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditorSession {
+    pub session_id: String,
+    pub renderer_pid: i32,
+    pub title: String,
+    pub path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceResolution {
+    Exact,
+    Inferred,
+    Unresolved,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EditorWindow {
+    pub runtime_id: String,
+    pub id: u32,
+    pub name: String,
+    pub path: String,
+    pub branch: Option<String>,
+    pub repository_id: Option<String>,
+    pub repository_name: Option<String>,
+    pub bundle_id: String,
+    pub editor_name: String,
+    pub resolution: WorkspaceResolution,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EditorState {
+    pub is_active: bool,
+    pub windows: Vec<EditorWindow>,
+    pub active_index: Option<usize>,
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,8 +1,10 @@
 mod ax_helper;
 mod ax_observer;
 mod claude_status;
+mod cursor_ipc;
 mod editor;
 mod editor_config;
+mod editor_model;
 mod notification;
 mod observer;
 mod window_offset;
@@ -63,7 +65,7 @@ fn get_all_editor_windows() -> Vec<EditorWindow> {
 }
 
 #[tauri::command]
-fn get_windows_snapshot() -> Vec<EditorWindow> {
+fn get_windows_snapshot() -> window_registry::WindowsSnapshot {
     window_registry::snapshot()
 }
 

--- a/src-tauri/src/window_registry.rs
+++ b/src-tauri/src/window_registry.rs
@@ -1,7 +1,7 @@
 //! Central window registry - single source of truth for editor windows.
 //!
 //! AX events, app activation, and startup all funnel through `request_refresh()`.
-//! The registry pulls a fresh list via `editor::get_all_editor_windows()`, diffs
+//! The registry pulls a fresh list via `editor::get_all_editor_window_snapshot()`, diffs
 //! against the last snapshot, and emits `windows:snapshot` only when something
 //! actually changed.
 //!
@@ -9,14 +9,13 @@
 //! - **transient-empty retry**: if AX returns empty while editors are still
 //!   running, re-query after a brief pause before believing the empty result.
 //! - **cold-start retry**: after a refresh leaves the registry empty while an
-//!   editor is running, schedule a few more attempts. At most one chain runs
-//!   at a time (guarded by `COLD_START_RETRY_BUSY`).
+//!   editor is running, the same worker performs a few more attempts.
 
 use crate::editor::EditorWindow;
 use crate::editor_config::EDITORS;
 use serde::Serialize;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::Mutex;
 use std::thread;
 use std::time::Duration;
@@ -24,58 +23,99 @@ use tauri::{AppHandle, Emitter, Manager};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct WindowsSnapshot {
+    pub revision: u64,
     pub windows: Vec<EditorWindow>,
     pub active_id: Option<u32>,
     pub source: String,
 }
 
 struct RegistryState {
+    revision: u64,
     windows: Vec<EditorWindow>,
     active_id: Option<u32>,
     /// Last-seen PID per editor_id. Used to detect editor restarts so we can
     /// invalidate editor.rs's workspace.json cache for the restarted editor.
     editor_pids: HashMap<String, i32>,
     app_handle: Option<AppHandle>,
+    refresh_tx: Option<Sender<String>>,
 }
 
 lazy_static::lazy_static! {
     static ref REGISTRY: Mutex<RegistryState> = Mutex::new(RegistryState {
+        revision: 0,
         windows: Vec::new(),
         active_id: None,
         editor_pids: HashMap::new(),
         app_handle: None,
+        refresh_tx: None,
     });
 }
 
-static COLD_START_RETRY_BUSY: AtomicBool = AtomicBool::new(false);
 const COLD_START_RETRIES: u32 = 6;
 const COLD_START_INTERVAL_MS: u64 = 500;
 const TRANSIENT_EMPTY_RECHECK_MS: u64 = 150;
 
 /// Initialize the registry with the Tauri AppHandle. Called once at startup.
 pub fn init(app_handle: AppHandle) {
-    let mut state = REGISTRY.lock().expect("registry mutex poisoned");
-    state.app_handle = Some(app_handle);
+    let (refresh_tx, refresh_rx) = mpsc::channel::<String>();
+    {
+        let mut state = REGISTRY.lock().expect("registry mutex poisoned");
+        state.app_handle = Some(app_handle);
+        state.refresh_tx = Some(refresh_tx);
+    }
+    thread::spawn(move || run_refresh_worker(refresh_rx));
+}
+
+fn run_refresh_worker(refresh_rx: Receiver<String>) {
+    while let Ok(mut source) = refresh_rx.recv() {
+        while let Ok(next_source) = refresh_rx.try_recv() {
+            source = next_source;
+        }
+        refresh_sync(&source);
+
+        if has_current_windows() || !any_editor_running() {
+            continue;
+        }
+        for _ in 0..COLD_START_RETRIES {
+            thread::sleep(Duration::from_millis(COLD_START_INTERVAL_MS));
+            if !any_editor_running() {
+                break;
+            }
+            source = "cold-start-retry".to_string();
+            while let Ok(next_source) = refresh_rx.try_recv() {
+                source = next_source;
+            }
+            refresh_sync(&source);
+            if has_current_windows() {
+                break;
+            }
+        }
+    }
 }
 
 /// Return the currently cached snapshot.
-pub fn snapshot() -> Vec<EditorWindow> {
-    REGISTRY
-        .lock()
-        .expect("registry mutex poisoned")
-        .windows
-        .clone()
+pub fn snapshot() -> WindowsSnapshot {
+    let state = REGISTRY.lock().expect("registry mutex poisoned");
+    WindowsSnapshot {
+        revision: state.revision,
+        windows: state.windows.clone(),
+        active_id: state.active_id,
+        source: "snapshot".to_string(),
+    }
 }
 
 /// Request an async refresh. The AX query + diff + emit runs on a background
 /// thread so callers (main thread AX observer callbacks, notification blocks)
-/// do not block. A cold-start retry chain may follow if the snapshot remains
-/// empty while editors are running.
-pub fn request_refresh(source: &'static str) {
-    thread::spawn(move || {
-        refresh_sync(source);
-        maybe_schedule_cold_start_retry();
-    });
+/// do not block. Cold-start retries run on that same worker.
+pub fn request_refresh(source: &str) {
+    let refresh_tx = REGISTRY
+        .lock()
+        .expect("registry mutex poisoned")
+        .refresh_tx
+        .clone();
+    if let Some(refresh_tx) = refresh_tx {
+        let _ = refresh_tx.send(source.to_string());
+    }
 }
 
 /// Synchronous refresh. Runs the AX query on the calling thread. Returns true
@@ -85,20 +125,15 @@ pub fn refresh_sync(source: &str) -> bool {
     // re-reading window metadata.
     reconcile_editor_pids();
 
-    let new_windows = crate::editor::get_all_editor_windows();
-    let new_active = crate::editor::get_active_window_id();
+    let (new_windows, new_active) = crate::editor::get_all_editor_window_snapshot();
 
     // Transient-empty guard: if AX returned no windows but we previously had
     // some and an editor is still running, treat this as a flicker and re-
     // query after a brief pause before believing the empty result.
-    if new_windows.is_empty()
-        && has_current_windows()
-        && any_editor_running()
-    {
+    if new_windows.is_empty() && has_current_windows() && any_editor_running() {
         thread::sleep(Duration::from_millis(TRANSIENT_EMPTY_RECHECK_MS));
-        let rechecked = crate::editor::get_all_editor_windows();
+        let (rechecked, rechecked_active) = crate::editor::get_all_editor_window_snapshot();
         if !rechecked.is_empty() {
-            let rechecked_active = crate::editor::get_active_window_id();
             return apply_snapshot(rechecked, rechecked_active, source);
         }
     }
@@ -111,21 +146,21 @@ fn apply_snapshot(
     new_active_id: Option<u32>,
     source: &str,
 ) -> bool {
-    let app_handle = {
+    let (app_handle, revision) = {
         let mut state = REGISTRY.lock().expect("registry mutex poisoned");
-        if !windows_differ(&state.windows, &new_windows)
-            && state.active_id == new_active_id
-        {
+        if !windows_differ(&state.windows, &new_windows) && state.active_id == new_active_id {
             return false;
         }
+        state.revision = state.revision.wrapping_add(1);
         state.windows = new_windows.clone();
         state.active_id = new_active_id;
-        state.app_handle.clone()
+        (state.app_handle.clone(), state.revision)
     };
 
     if let Some(handle) = app_handle {
         if let Some(window) = handle.get_webview_window("main") {
             let payload = WindowsSnapshot {
+                revision,
                 windows: new_windows,
                 active_id: new_active_id,
                 source: source.to_string(),
@@ -180,35 +215,6 @@ fn reconcile_editor_pids() {
     }
 }
 
-/// Start a cold-start retry chain if the registry is empty while editors run.
-/// Exactly one chain runs at a time.
-fn maybe_schedule_cold_start_retry() {
-    let should_retry = {
-        let state = REGISTRY.lock().expect("registry mutex poisoned");
-        state.windows.is_empty()
-    } && any_editor_running();
-
-    if !should_retry {
-        return;
-    }
-    if COLD_START_RETRY_BUSY.swap(true, Ordering::SeqCst) {
-        return;
-    }
-
-    thread::spawn(|| {
-        for _ in 0..COLD_START_RETRIES {
-            thread::sleep(Duration::from_millis(COLD_START_INTERVAL_MS));
-            if refresh_sync("cold-start-retry") {
-                break;
-            }
-            if !any_editor_running() {
-                break;
-            }
-        }
-        COLD_START_RETRY_BUSY.store(false, Ordering::SeqCst);
-    });
-}
-
 /// Two snapshots differ when length, or any identity field (id / name / branch /
 /// path / bundle_id) differs. Order is ignored — frontend reorders independently.
 fn windows_differ(a: &[EditorWindow], b: &[EditorWindow]) -> bool {
@@ -218,21 +224,20 @@ fn windows_differ(a: &[EditorWindow], b: &[EditorWindow]) -> bool {
 
     let mut a_sorted: Vec<&EditorWindow> = a.iter().collect();
     let mut b_sorted: Vec<&EditorWindow> = b.iter().collect();
-    a_sorted.sort_by_key(|w| w.id);
-    b_sorted.sort_by_key(|w| w.id);
+    a_sorted.sort_by_key(|window| (&window.bundle_id, window.id));
+    b_sorted.sort_by_key(|window| (&window.bundle_id, window.id));
 
-    a_sorted
-        .iter()
-        .zip(b_sorted.iter())
-        .any(|(wa, wb)| {
-            wa.id != wb.id
-                || wa.name != wb.name
-                || wa.branch != wb.branch
-                || wa.path != wb.path
-                || wa.repository_id != wb.repository_id
-                || wa.repository_name != wb.repository_name
-                || wa.bundle_id != wb.bundle_id
-        })
+    a_sorted.iter().zip(b_sorted.iter()).any(|(wa, wb)| {
+        wa.id != wb.id
+            || wa.runtime_id != wb.runtime_id
+            || wa.name != wb.name
+            || wa.branch != wb.branch
+            || wa.path != wb.path
+            || wa.repository_id != wb.repository_id
+            || wa.repository_name != wb.repository_name
+            || wa.bundle_id != wb.bundle_id
+            || wa.resolution != wb.resolution
+    })
 }
 
 #[cfg(test)]
@@ -241,6 +246,7 @@ mod tests {
 
     fn mk(id: u32, name: &str, bundle: &str) -> EditorWindow {
         EditorWindow {
+            runtime_id: format!("{}:{}", bundle, id),
             id,
             name: name.to_string(),
             path: String::new(),
@@ -249,6 +255,7 @@ mod tests {
             repository_name: None,
             bundle_id: bundle.to_string(),
             editor_name: String::new(),
+            resolution: crate::editor::WorkspaceResolution::Unresolved,
         }
     }
 
@@ -274,6 +281,13 @@ mod tests {
     }
 
     #[test]
+    fn reordering_across_editors_with_same_window_id_is_not_a_difference() {
+        let a = vec![mk(1, "alpha", "b1"), mk(1, "beta", "b2")];
+        let b = vec![mk(1, "beta", "b2"), mk(1, "alpha", "b1")];
+        assert!(!windows_differ(&a, &b));
+    }
+
+    #[test]
     fn length_change_is_detected() {
         let a = vec![mk(1, "alpha", "b1")];
         let b = vec![mk(1, "alpha", "b1"), mk(2, "beta", "b1")];
@@ -283,6 +297,7 @@ mod tests {
     #[test]
     fn branch_change_is_detected() {
         let a = vec![EditorWindow {
+            runtime_id: "b1:1".into(),
             id: 1,
             name: "p".into(),
             path: String::new(),
@@ -291,8 +306,10 @@ mod tests {
             repository_name: None,
             bundle_id: "b1".into(),
             editor_name: String::new(),
+            resolution: crate::editor::WorkspaceResolution::Unresolved,
         }];
         let b = vec![EditorWindow {
+            runtime_id: "b1:1".into(),
             id: 1,
             name: "p".into(),
             path: String::new(),
@@ -301,6 +318,7 @@ mod tests {
             repository_name: None,
             bundle_id: "b1".into(),
             editor_name: String::new(),
+            resolution: crate::editor::WorkspaceResolution::Unresolved,
         }];
         assert!(windows_differ(&a, &b));
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,6 +117,7 @@ function App() {
       onColorPickerOpen={lifecycle.handleColorPickerOpen}
       onColorPickerClose={lifecycle.handleColorPickerClose}
       showBranch={lifecycle.showBranch}
+      tabLayout={lifecycle.tabLayout}
       history={history.history}
       showAddMenu={history.showAddMenu}
       onAddMenuOpen={lifecycle.handleAddMenuOpen}

--- a/src/components/GroupTabList.tsx
+++ b/src/components/GroupTabList.tsx
@@ -63,7 +63,11 @@ function GroupTabList({
 }: GroupTabListProps) {
   const { t } = useTranslation();
   const menuRef = useRef<HTMLDivElement>(null);
-  const items = groupRepositoryTabs(entries);
+  const groupedItems = groupRepositoryTabs(entries);
+  const items = [
+    ...groupedItems.filter((item) => item.type === "repository"),
+    ...groupedItems.filter((item) => item.type === "tab"),
+  ];
   const visibleRowCount = items.reduce(
     (count, item) => count + (
       item.type === "repository" && expandedRepositories.has(item.key)

--- a/src/components/GroupTabList.tsx
+++ b/src/components/GroupTabList.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { getColorById } from "../constants/tabColors";
 import { EDITOR_DISPLAY_NAMES, type ClaudeStatus, type TabColorMap } from "../types/editor";
 import { groupRepositoryTabs, type TabEntry } from "../utils/repositoryTabs";
-import { getWindowScopedValue, legacyWindowKey } from "../utils/store";
+import { getWindowScopedValue, legacyWindowKey, runtimeWindowKey } from "../utils/store";
 
 interface GroupTabListProps {
   name: string;
@@ -14,6 +14,7 @@ interface GroupTabListProps {
   tabColors?: TabColorMap;
   showBranch: boolean;
   anchorLeft: number;
+  expandedRepositories: ReadonlySet<string>;
   onTabClick: (index: number) => void;
   onCloseTab: (index: number) => void;
   onRequestClose: () => void;
@@ -29,6 +30,7 @@ interface GroupTabListProps {
   onDragOver: (index: number) => void;
   onDrop: (index: number) => void;
   onRowCountChange: (rowCount: number) => Promise<void>;
+  onToggleRepository: (repositoryId: string) => void;
 }
 
 const MENU_WIDTH = 360;
@@ -46,6 +48,7 @@ function GroupTabList({
   tabColors,
   showBranch,
   anchorLeft,
+  expandedRepositories,
   onTabClick,
   onCloseTab,
   onRequestClose,
@@ -56,10 +59,10 @@ function GroupTabList({
   onDragOver,
   onDrop,
   onRowCountChange,
+  onToggleRepository,
 }: GroupTabListProps) {
   const { t } = useTranslation();
   const menuRef = useRef<HTMLDivElement>(null);
-  const [expandedRepositories, setExpandedRepositories] = useState<Set<string>>(() => new Set());
   const items = groupRepositoryTabs(entries);
   const visibleRowCount = items.reduce(
     (count, item) => count + (
@@ -87,18 +90,6 @@ function GroupTabList({
     void onRowCountChange(visibleRowCount);
   }, [onRowCountChange, visibleRowCount]);
 
-  const toggleRepository = (repositoryId: string) => {
-    setExpandedRepositories((current) => {
-      const next = new Set(current);
-      if (next.has(repositoryId)) {
-        next.delete(repositoryId);
-      } else {
-        next.add(repositoryId);
-      }
-      return next;
-    });
-  };
-
   const renderTabRow = ({ tab, originalIndex }: TabEntry, nested = false) => {
     const isActive = originalIndex === activeIndex;
     const status = statuses.get(originalIndex);
@@ -109,7 +100,7 @@ function GroupTabList({
 
     return (
       <div
-        key={`${tab.bundle_id}:${tab.id}`}
+        key={runtimeWindowKey(tab)}
         style={{
           ...styles.row,
           ...(nested ? styles.nestedRow : {}),
@@ -213,7 +204,7 @@ function GroupTabList({
                 aria-expanded={isExpanded}
                 aria-current={isParentActive ? "page" : undefined}
                 style={styles.tabButton}
-                onClick={() => toggleRepository(item.key)}
+                onClick={() => onToggleRepository(item.key)}
                 onContextMenu={(event) => {
                   event.preventDefault();
                   onRepositoryContextMenu(

--- a/src/components/GroupTabList.tsx
+++ b/src/components/GroupTabList.tsx
@@ -1,0 +1,381 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+import { getColorById } from "../constants/tabColors";
+import { EDITOR_DISPLAY_NAMES, type ClaudeStatus, type TabColorMap } from "../types/editor";
+import { groupRepositoryTabs, type TabEntry } from "../utils/repositoryTabs";
+import { getWindowScopedValue, legacyWindowKey } from "../utils/store";
+
+interface GroupTabListProps {
+  name: string;
+  entries: TabEntry[];
+  activeIndex: number;
+  statuses: Map<number, ClaudeStatus | undefined>;
+  tabColors?: TabColorMap;
+  showBranch: boolean;
+  anchorLeft: number;
+  onTabClick: (index: number) => void;
+  onCloseTab: (index: number) => void;
+  onRequestClose: () => void;
+  onTabContextMenu: (index: number, rect: DOMRect) => void;
+  onRepositoryContextMenu: (
+    repositoryId: string,
+    indices: number[],
+    preferredIndex: number,
+    rect: DOMRect,
+  ) => void;
+  onDragStart: (index: number) => void;
+  onDragEnd: () => void;
+  onDragOver: (index: number) => void;
+  onDrop: (index: number) => void;
+  onRowCountChange: (rowCount: number) => Promise<void>;
+}
+
+const MENU_WIDTH = 360;
+
+function getColorBorder(colorId?: string | null): React.CSSProperties {
+  const color = getColorById(colorId);
+  return color ? { borderLeftColor: color.hex } : {};
+}
+
+function GroupTabList({
+  name,
+  entries,
+  activeIndex,
+  statuses,
+  tabColors,
+  showBranch,
+  anchorLeft,
+  onTabClick,
+  onCloseTab,
+  onRequestClose,
+  onTabContextMenu,
+  onRepositoryContextMenu,
+  onDragStart,
+  onDragEnd,
+  onDragOver,
+  onDrop,
+  onRowCountChange,
+}: GroupTabListProps) {
+  const { t } = useTranslation();
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [expandedRepositories, setExpandedRepositories] = useState<Set<string>>(() => new Set());
+  const items = groupRepositoryTabs(entries);
+  const visibleRowCount = items.reduce(
+    (count, item) => count + (
+      item.type === "repository" && expandedRepositories.has(item.key)
+        ? item.entries.length
+        : 0
+    ),
+    items.length,
+  );
+  const left = Math.min(
+    Math.max(8, anchorLeft),
+    Math.max(8, window.innerWidth - MENU_WIDTH - 8),
+  );
+
+  useEffect(() => {
+    const handlePointerDown = (event: MouseEvent) => {
+      if (menuRef.current?.contains(event.target as Node)) return;
+      onRequestClose();
+    };
+    document.addEventListener("mousedown", handlePointerDown, true);
+    return () => document.removeEventListener("mousedown", handlePointerDown, true);
+  }, [onRequestClose]);
+
+  useEffect(() => {
+    void onRowCountChange(visibleRowCount);
+  }, [onRowCountChange, visibleRowCount]);
+
+  const toggleRepository = (repositoryId: string) => {
+    setExpandedRepositories((current) => {
+      const next = new Set(current);
+      if (next.has(repositoryId)) {
+        next.delete(repositoryId);
+      } else {
+        next.add(repositoryId);
+      }
+      return next;
+    });
+  };
+
+  const renderTabRow = ({ tab, originalIndex }: TabEntry, nested = false) => {
+    const isActive = originalIndex === activeIndex;
+    const status = statuses.get(originalIndex);
+    const branchName = tab.branch || tab.name || t("app.untitled");
+    const colorId = tabColors
+      ? getWindowScopedValue(tabColors, tab, legacyWindowKey(tab)) ?? null
+      : null;
+
+    return (
+      <div
+        key={`${tab.bundle_id}:${tab.id}`}
+        style={{
+          ...styles.row,
+          ...(nested ? styles.nestedRow : {}),
+          ...(isActive ? styles.rowActive : {}),
+        }}
+        draggable
+        onDragStart={(event) => {
+          event.dataTransfer.setData("text/plain", originalIndex.toString());
+          event.dataTransfer.effectAllowed = "move";
+          onDragStart(originalIndex);
+        }}
+        onDragEnd={onDragEnd}
+        onDragOver={(event) => {
+          event.preventDefault();
+          event.dataTransfer.dropEffect = "move";
+          onDragOver(originalIndex);
+        }}
+        onDrop={(event) => {
+          event.preventDefault();
+          onDrop(originalIndex);
+        }}
+      >
+        <button
+          type="button"
+          role="menuitem"
+          aria-current={isActive ? "page" : undefined}
+          data-tab-index={originalIndex}
+          style={{
+            ...styles.tabButton,
+            ...getColorBorder(colorId),
+          }}
+          onClick={() => {
+            onTabClick(originalIndex);
+            onRequestClose();
+          }}
+          onContextMenu={(event) => {
+            event.preventDefault();
+            onTabContextMenu(originalIndex, event.currentTarget.getBoundingClientRect());
+          }}
+        >
+          {nested && <span aria-hidden="true" style={styles.branchIndicator}>⑂</span>}
+          <span style={styles.tabText}>
+            <span style={styles.tabName}>{nested ? branchName : tab.name || t("app.untitled")}</span>
+            {!nested && showBranch && tab.branch && (
+              <span style={styles.branchName}>⑂ {tab.branch}</span>
+            )}
+          </span>
+          <span style={styles.editorName}>
+            {EDITOR_DISPLAY_NAMES[tab.bundle_id] || tab.editor_name}
+          </span>
+          {status === "waiting" && <span style={styles.badgeWaiting} />}
+          {status === "generating" && <span style={styles.badgeGenerating} className="pulse-animation" />}
+        </button>
+        <button
+          type="button"
+          style={styles.closeButton}
+          onClick={() => onCloseTab(originalIndex)}
+          aria-label={t("worktree.closeBranch", { branch: branchName })}
+          title={t("tabBar.closeTooltip")}
+        >
+          ×
+        </button>
+      </div>
+    );
+  };
+
+  return createPortal(
+    <div
+      ref={menuRef}
+      role="menu"
+      aria-label={t("group.tabList", { name })}
+      style={{ ...styles.menu, left }}
+      onKeyDown={(event) => {
+        if (event.key === "Escape") {
+          event.stopPropagation();
+          onRequestClose();
+        }
+      }}
+    >
+      {items.map((item) => {
+        if (item.type === "tab") return renderTabRow(item.entry);
+
+        const indices = item.entries.map((entry) => entry.originalIndex);
+        const activeEntry = item.entries.find((entry) => entry.originalIndex === activeIndex);
+        const isExpanded = expandedRepositories.has(item.key);
+        const isParentActive = Boolean(activeEntry) && !isExpanded;
+        const preferredIndex = activeEntry?.originalIndex ?? indices[0];
+        const hasWaiting = item.entries.some(
+          (entry) => statuses.get(entry.originalIndex) === "waiting",
+        );
+        const hasGenerating = item.entries.some(
+          (entry) => statuses.get(entry.originalIndex) === "generating",
+        );
+
+        return (
+          <div key={item.key} role="group" aria-label={item.name} style={styles.repositoryGroup}>
+            <div style={{ ...styles.row, ...(isParentActive ? styles.rowActive : {}) }}>
+              <button
+                type="button"
+                role="menuitem"
+                aria-expanded={isExpanded}
+                aria-current={isParentActive ? "page" : undefined}
+                style={styles.tabButton}
+                onClick={() => toggleRepository(item.key)}
+                onContextMenu={(event) => {
+                  event.preventDefault();
+                  onRepositoryContextMenu(
+                    item.key,
+                    indices,
+                    preferredIndex,
+                    event.currentTarget.getBoundingClientRect(),
+                  );
+                }}
+              >
+                <span aria-hidden="true" style={styles.disclosureIcon}>
+                  {isExpanded ? "▾" : "▸"}
+                </span>
+                <span style={styles.tabText}>
+                  <span style={styles.tabName}>{item.name}</span>
+                </span>
+                <span style={styles.count}>{item.entries.length}</span>
+                {hasGenerating && <span style={styles.badgeGenerating} className="pulse-animation" />}
+                {!hasGenerating && hasWaiting && <span style={styles.badgeWaiting} />}
+              </button>
+            </div>
+            {isExpanded && (
+              <div style={styles.repositoryRows}>
+                {item.entries.map((entry) => renderTabRow(entry, true))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>,
+    document.body,
+  );
+}
+
+const badgeStyle: React.CSSProperties = {
+  width: "8px",
+  height: "8px",
+  borderRadius: "50%",
+  flexShrink: 0,
+};
+
+const styles: Record<string, React.CSSProperties> = {
+  menu: {
+    position: "fixed",
+    top: "36px",
+    width: `${MENU_WIDTH}px`,
+    maxHeight: "400px",
+    overflowY: "auto",
+    padding: "4px",
+    border: "1px solid rgba(255, 255, 255, 0.15)",
+    borderRadius: "0 0 6px 6px",
+    background: "#2d2d2d",
+    boxShadow: "0 4px 12px rgba(0, 0, 0, 0.5)",
+    zIndex: 1001,
+  },
+  repositoryGroup: {
+    padding: 0,
+  },
+  count: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    minWidth: "18px",
+    height: "18px",
+    padding: "0 5px",
+    borderRadius: "9px",
+    background: "rgba(255, 255, 255, 0.12)",
+    color: "rgba(255, 255, 255, 0.75)",
+    fontSize: "10px",
+    fontWeight: 600,
+    fontVariantNumeric: "tabular-nums",
+  },
+  repositoryRows: {
+    paddingLeft: "16px",
+  },
+  row: {
+    display: "flex",
+    alignItems: "center",
+    minHeight: "32px",
+    borderRadius: "4px",
+    overflow: "hidden",
+  },
+  rowActive: {
+    background: "rgba(0, 122, 255, 0.18)",
+  },
+  nestedRow: {
+    marginTop: "2px",
+  },
+  tabButton: {
+    display: "flex",
+    alignItems: "center",
+    minWidth: 0,
+    flex: 1,
+    height: "32px",
+    padding: "0 8px",
+    gap: "7px",
+    border: "none",
+    borderLeft: "3px solid transparent",
+    borderRadius: "4px",
+    background: "transparent",
+    color: "rgba(255, 255, 255, 0.85)",
+    cursor: "pointer",
+    textAlign: "left",
+  },
+  branchIndicator: {
+    color: "rgba(255, 255, 255, 0.4)",
+    fontSize: "11px",
+    flexShrink: 0,
+  },
+  disclosureIcon: {
+    width: "10px",
+    color: "rgba(255, 255, 255, 0.55)",
+    fontSize: "10px",
+    flexShrink: 0,
+    textAlign: "center",
+  },
+  tabText: {
+    display: "flex",
+    flexDirection: "column",
+    flex: 1,
+    minWidth: 0,
+  },
+  tabName: {
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    fontSize: "12px",
+  },
+  branchName: {
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    color: "rgba(255, 255, 255, 0.5)",
+    fontSize: "10px",
+  },
+  editorName: {
+    flexShrink: 0,
+    color: "rgba(255, 255, 255, 0.5)",
+    fontSize: "10px",
+  },
+  closeButton: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "28px",
+    height: "28px",
+    padding: 0,
+    border: "none",
+    borderRadius: "4px",
+    background: "transparent",
+    color: "rgba(255, 255, 255, 0.6)",
+    cursor: "pointer",
+    fontSize: "14px",
+  },
+  badgeWaiting: {
+    ...badgeStyle,
+    backgroundColor: "#007aff",
+  },
+  badgeGenerating: {
+    ...badgeStyle,
+    backgroundColor: "#ff3b30",
+  },
+};
+
+export default GroupTabList;

--- a/src/components/Settings.test.tsx
+++ b/src/components/Settings.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { emit } from "@tauri-apps/api/event";
+import Settings from "./Settings";
+
+const storeMocks = vi.hoisted(() => ({
+  getStore: vi.fn().mockResolvedValue({
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue(undefined),
+  }),
+  loadTabLayout: vi.fn().mockResolvedValue("horizontal"),
+  saveTabLayout: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../utils/store", () => storeMocks);
+
+vi.mock("../hooks/useLanguage", () => ({
+  useLanguage: () => ({
+    language: "ja",
+    changeLanguage: vi.fn(),
+  }),
+}));
+
+vi.mock("@tauri-apps/api/path", () => ({
+  homeDir: vi.fn().mockResolvedValue("/Users/test"),
+}));
+
+describe("Settings tab layout", () => {
+  beforeEach(() => {
+    storeMocks.loadTabLayout.mockClear();
+    storeMocks.saveTabLayout.mockClear();
+    vi.mocked(emit).mockClear();
+  });
+
+  it("loads the saved layout and emits changes", async () => {
+    render(<Settings />);
+
+    const horizontal = await screen.findByRole("radio", {
+      name: /settings\.tabLayout\.horizontal/,
+    });
+    const list = screen.getByRole("radio", {
+      name: /settings\.tabLayout\.list/,
+    });
+
+    expect(horizontal).toBeChecked();
+    expect(storeMocks.loadTabLayout).toHaveBeenCalledOnce();
+
+    fireEvent.click(list);
+
+    await waitFor(() => {
+      expect(storeMocks.saveTabLayout).toHaveBeenCalledWith("list");
+      expect(emit).toHaveBeenCalledWith("tab-layout-changed", "list");
+    });
+    expect(list).toBeChecked();
+  });
+});

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
+import { emit } from "@tauri-apps/api/event";
 import { homeDir } from "@tauri-apps/api/path";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { enable, disable, isEnabled } from "@tauri-apps/plugin-autostart";
 import { useLanguage } from "../hooks/useLanguage";
-import { getStore } from "../utils/store";
+import type { TabLayout } from "../types/editor";
+import { getStore, loadTabLayout, saveTabLayout } from "../utils/store";
 import VersionInfo from "./VersionInfo";
 
 function highlightJSON(json: string): React.ReactNode[] {
@@ -104,6 +106,7 @@ function Settings() {
   const [notificationEnabled, setNotificationEnabled] = useState(true);
   const [autostartEnabled, setAutostartEnabled] = useState(false);
   const [showBranchEnabled, setShowBranchEnabled] = useState(true);
+  const [tabLayout, setTabLayout] = useState<TabLayout>("horizontal");
 
   useEffect(() => {
     getCurrentWindow().setTitle(t("settings.title"));
@@ -117,6 +120,7 @@ function Settings() {
         if (notif !== null && notif !== undefined) setNotificationEnabled(notif);
         const branch = await store.get<boolean>("settings:showBranch");
         if (branch !== null && branch !== undefined) setShowBranchEnabled(branch);
+        setTabLayout(await loadTabLayout());
       } catch { /* defaults */ }
       try {
         setAutostartEnabled(await isEnabled());
@@ -156,6 +160,12 @@ function Settings() {
     } catch (error) {
       console.error("Failed to save showBranch setting:", error);
     }
+  }, []);
+
+  const handleTabLayoutChange = useCallback(async (layout: TabLayout) => {
+    setTabLayout(layout);
+    await saveTabLayout(layout);
+    await emit("tab-layout-changed", layout);
   }, []);
 
   const handleCopy = useCallback(async () => {
@@ -381,6 +391,40 @@ function Settings() {
                 }}
               />
             </div>
+          </div>
+        </div>
+
+        {/* タブ表示形式 */}
+        <div style={styles.card}>
+          <div style={styles.switchLabel}>{t("settings.tabLayoutLabel")}</div>
+          <p style={{ ...styles.switchDescription, ...styles.layoutDescription }}>
+            {t("settings.tabLayoutDescription")}
+          </p>
+          <div style={styles.layoutOptions}>
+            {(["horizontal", "list"] as const).map((layout) => (
+              <label
+                key={layout}
+                style={{
+                  ...styles.layoutOption,
+                  ...(tabLayout === layout ? styles.layoutOptionActive : {}),
+                }}
+              >
+                <input
+                  type="radio"
+                  name="tab-layout"
+                  value={layout}
+                  checked={tabLayout === layout}
+                  onChange={() => handleTabLayoutChange(layout)}
+                  style={styles.layoutRadio}
+                />
+                <span style={styles.layoutOptionText}>
+                  <span style={styles.switchLabel}>{t(`settings.tabLayout.${layout}`)}</span>
+                  <span style={styles.switchDescription}>
+                    {t(`settings.tabLayout.${layout}Description`)}
+                  </span>
+                </span>
+              </label>
+            ))}
           </div>
         </div>
 
@@ -649,6 +693,40 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: "12px",
     cursor: "pointer",
     flexShrink: 0,
+  },
+  layoutDescription: {
+    margin: "4px 0 12px",
+  },
+  layoutOptions: {
+    display: "grid",
+    gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+    gap: "8px",
+  },
+  layoutOption: {
+    display: "flex",
+    alignItems: "flex-start",
+    gap: "8px",
+    padding: "10px",
+    borderWidth: "1px",
+    borderStyle: "solid",
+    borderColor: "#404040",
+    borderRadius: "6px",
+    cursor: "pointer",
+    background: "#2d2d2d",
+  },
+  layoutOptionActive: {
+    borderColor: "#0066cc",
+    background: "rgba(0, 102, 204, 0.12)",
+  },
+  layoutRadio: {
+    accentColor: "#007aff",
+    margin: "2px 0 0",
+    flexShrink: 0,
+  },
+  layoutOptionText: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "2px",
   },
 };
 

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -25,11 +25,26 @@ const vscodeWorktree: EditorWindow = {
   editor_name: "VSCode",
 };
 
-function setup(tabColors: Record<string, string | null> = {}, tabLayout: "horizontal" | "list" = "horizontal") {
+const zedWorktree: EditorWindow = {
+  id: 3,
+  name: "medii-e-consult-front",
+  path: "/Users/test/.codex/worktrees/c3d4/medii-e-consult-front",
+  branch: "fix/validation",
+  repository_id: "/Users/test/projects/medii-e-consult-front/.git",
+  repository_name: "medii-e-consult-front",
+  bundle_id: "dev.zed.Zed",
+  editor_name: "Zed",
+};
+
+function setup(
+  tabColors: Record<string, string | null> = {},
+  tabLayout: "horizontal" | "list" = "horizontal",
+  tabs: EditorWindow[] = [cursorWindow, vscodeWorktree],
+) {
   const onAssignTabsToGroup = vi.fn();
   const onColorChange = vi.fn();
   const props = {
-    tabs: [cursorWindow, vscodeWorktree],
+    tabs,
     activeIndex: 0,
     onTabClick: vi.fn(),
     onNewTab: vi.fn(),
@@ -68,8 +83,15 @@ function setup(tabColors: Record<string, string | null> = {}, tabLayout: "horizo
     onWorktreeMenuClose: vi.fn().mockResolvedValue(undefined),
   };
 
-  render(<TabBar {...props} />);
-  return { props, onAssignTabsToGroup, onColorChange };
+  const view = render(<TabBar {...props} />);
+  return {
+    props,
+    onAssignTabsToGroup,
+    onColorChange,
+    rerenderTabs: (nextTabs: EditorWindow[]) => {
+      view.rerender(<TabBar {...props} tabs={nextTabs} />);
+    },
+  };
 }
 
 describe("TabBar repository grouping", () => {
@@ -145,6 +167,29 @@ describe("TabBar repository grouping", () => {
     expect(screen.getByRole("menuitem", { name: /main/ })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: /feature\/search/ })).toBeInTheDocument();
     expect(props.onWorktreeMenuOpen).toHaveBeenLastCalledWith(3);
+  });
+
+  it("keeps a repository expanded after a tab closes and the list reopens", () => {
+    const { props, rerenderTabs } = setup(
+      {},
+      "list",
+      [cursorWindow, vscodeWorktree, zedWorktree],
+    );
+    const groupButton = screen.getByRole("button", { name: /medii/ });
+    fireEvent.click(groupButton);
+    fireEvent.click(screen.getByRole("menuitem", { name: /medii-e-consult-front/ }));
+
+    fireEvent.click(screen.getAllByRole("button", { name: "worktree.closeBranch" })[2]);
+    expect(props.onCloseTab).toHaveBeenCalledWith(2);
+    rerenderTabs([cursorWindow, vscodeWorktree]);
+
+    fireEvent.click(groupButton);
+    fireEvent.click(groupButton);
+
+    const repository = screen.getByRole("menuitem", { name: /medii-e-consult-front/ });
+    expect(repository).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("menuitem", { name: /main/ })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /feature\/search/ })).toBeInTheDocument();
   });
 
   it("switches windows from the group list and closes it", () => {

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -25,7 +25,7 @@ const vscodeWorktree: EditorWindow = {
   editor_name: "VSCode",
 };
 
-function setup(tabColors: Record<string, string | null> = {}) {
+function setup(tabColors: Record<string, string | null> = {}, tabLayout: "horizontal" | "list" = "horizontal") {
   const onAssignTabsToGroup = vi.fn();
   const onColorChange = vi.fn();
   const props = {
@@ -45,6 +45,7 @@ function setup(tabColors: Record<string, string | null> = {}) {
     onColorPickerOpen: vi.fn().mockResolvedValue(undefined),
     onColorPickerClose: vi.fn(),
     tabColors,
+    tabLayout,
     onColorChange,
     groups: [
       { id: "medii", name: "medii", order: 0 },
@@ -123,5 +124,38 @@ describe("TabBar repository grouping", () => {
     fireEvent.click(await screen.findByTitle("tabColor.blue"));
 
     expect(onColorChange).toHaveBeenCalledWith(colorKey, "blue");
+  });
+
+  it("shows grouped worktrees as rows in list layout", () => {
+    const { props } = setup({}, "list");
+    const groupButton = screen.getByRole("button", { name: /medii/ });
+
+    expect(screen.queryByRole("button", { name: "worktree.openBranches" })).not.toBeInTheDocument();
+
+    fireEvent.click(groupButton);
+
+    expect(screen.getByRole("menu", { name: "group.tabList" })).toBeInTheDocument();
+    const repository = screen.getByRole("menuitem", { name: /medii-e-consult-front/ });
+    expect(repository).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("menuitem", { name: /main/ })).not.toBeInTheDocument();
+    expect(props.onWorktreeMenuOpen).toHaveBeenLastCalledWith(1);
+
+    fireEvent.click(repository);
+
+    expect(screen.getByRole("menuitem", { name: /main/ })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /feature\/search/ })).toBeInTheDocument();
+    expect(props.onWorktreeMenuOpen).toHaveBeenLastCalledWith(3);
+  });
+
+  it("switches windows from the group list and closes it", () => {
+    const { props } = setup({}, "list");
+    fireEvent.click(screen.getByRole("button", { name: /medii/ }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /medii-e-consult-front/ }));
+
+    fireEvent.click(screen.getByRole("menuitem", { name: /feature\/search/ }));
+
+    expect(props.onTabClick).toHaveBeenCalledWith(1);
+    expect(props.onWorktreeMenuClose).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menu", { name: "group.tabList" })).not.toBeInTheDocument();
   });
 });

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -36,10 +36,22 @@ const zedWorktree: EditorWindow = {
   editor_name: "Zed",
 };
 
+const standaloneWindow: EditorWindow = {
+  id: 4,
+  name: "medii-e-consult-api",
+  path: "/Users/test/projects/medii-e-consult-api",
+  branch: "main",
+  bundle_id: "com.todesktop.230313mzl4w4u92",
+  editor_name: "Cursor",
+};
+
 function setup(
   tabColors: Record<string, string | null> = {},
   tabLayout: "horizontal" | "list" = "horizontal",
   tabs: EditorWindow[] = [cursorWindow, vscodeWorktree],
+  groupAssignments: Record<string, string | null> = {
+    [windowKey(cursorWindow)]: "medii",
+  },
 ) {
   const onAssignTabsToGroup = vi.fn();
   const onColorChange = vi.fn();
@@ -66,7 +78,7 @@ function setup(
       { id: "medii", name: "medii", order: 0 },
       { id: "personal", name: "personal", order: 1 },
     ],
-    groupAssignments: { [windowKey(cursorWindow)]: "medii" },
+    groupAssignments,
     collapsedGroups: new Set<string>(),
     onAddGroup: vi.fn(() => "new-group"),
     onUpdateGroup: vi.fn(),
@@ -167,6 +179,24 @@ describe("TabBar repository grouping", () => {
     expect(screen.getByRole("menuitem", { name: /main/ })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: /feature\/search/ })).toBeInTheDocument();
     expect(props.onWorktreeMenuOpen).toHaveBeenLastCalledWith(3);
+  });
+
+  it("shows repository worktree rows before regular tabs in list layout", () => {
+    setup(
+      {},
+      "list",
+      [standaloneWindow, cursorWindow, vscodeWorktree],
+      {
+        [windowKey(standaloneWindow)]: "medii",
+        [windowKey(cursorWindow)]: "medii",
+      },
+    );
+    fireEvent.click(screen.getByRole("button", { name: /medii/ }));
+
+    const items = within(screen.getByRole("menu", { name: "group.tabList" }))
+      .getAllByRole("menuitem");
+    expect(items[0]).toHaveTextContent("medii-e-consult-front");
+    expect(items[1]).toHaveTextContent("medii-e-consult-api");
   });
 
   it("keeps a repository expanded after a tab closes and the list reopens", () => {

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -6,7 +6,7 @@ import GroupTabList from "./GroupTabList";
 import ColorPicker from "./ColorPicker";
 import AddTabMenu from "./AddTabMenu";
 import type { EditorWindow, ClaudeStatus, HistoryEntry, GroupDefinition, GroupAssignment, TabColorMap, TabLayout } from "../types/editor";
-import { getWindowScopedValue, legacyWindowKey, projectPathMatchesWindow, repositoryColorKey, windowKey } from "../utils/store";
+import { getWindowScopedValue, legacyWindowKey, projectPathMatchesWindow, repositoryColorKey, runtimeWindowKey, windowKey } from "../utils/store";
 import { getColorById } from "../constants/tabColors";
 import { getInheritedRepositoryGroupId, groupRepositoryTabs, type TabEntry } from "../utils/repositoryTabs";
 
@@ -60,7 +60,20 @@ const getClaudeStatusForTab = (tab: EditorWindow, statuses?: Record<string, Clau
   return undefined;
 };
 
-const getListRowCount = (entries: TabEntry[]) => groupRepositoryTabs(entries).length;
+const getListRowCount = (
+  entries: TabEntry[],
+  expandedRepositories: ReadonlySet<string>,
+) => {
+  const items = groupRepositoryTabs(entries);
+  return items.reduce(
+    (count, item) => count + (
+      item.type === "repository" && expandedRepositories.has(item.key)
+        ? item.entries.length
+        : 0
+    ),
+    items.length,
+  );
+};
 
 function TabBar(props: TabBarProps) {
   const { tabs, activeIndex, onTabClick, onNewTab, onCloseTab, onReorder, onReorderByVisual, claudeStatuses, tabColors, onColorChange, showBranch, tabLayout, history, showAddMenu, onAddMenuOpen, onAddMenuClose, onHistorySelect, onHistoryClear, onColorPickerOpen, onColorPickerClose, groups, groupAssignments, collapsedGroups, onAddGroup, onUpdateGroup, onDeleteGroup, onAssignTabsToGroup, onUnassignTabsFromGroup, onToggleGroupCollapse, onReorderGroups, groupColors, onSetGroupColor, onTabContextMenuOpen, onTabContextMenuClose, onWorktreeMenuOpen, onWorktreeMenuClose } = props;
@@ -79,6 +92,7 @@ function TabBar(props: TabBarProps) {
   const [groupColorPickerAnchorLeft, setGroupColorPickerAnchorLeft] = useState<number>(0);
   const [openGroupId, setOpenGroupId] = useState<string | null>(null);
   const [groupListAnchorLeft, setGroupListAnchorLeft] = useState(8);
+  const [expandedRepositories, setExpandedRepositories] = useState<Set<string>>(() => new Set());
   const containerRef = useRef<HTMLDivElement>(null);
   const tabsWrapperRef = useRef<HTMLDivElement>(null);
   const addButtonRef = useRef<HTMLButtonElement>(null);
@@ -151,6 +165,18 @@ function TabBar(props: TabBarProps) {
     void onWorktreeMenuClose();
   }, [onWorktreeMenuClose, openGroupId]);
 
+  const toggleRepositoryExpansion = useCallback((repositoryId: string) => {
+    setExpandedRepositories((current) => {
+      const next = new Set(current);
+      if (next.has(repositoryId)) {
+        next.delete(repositoryId);
+      } else {
+        next.add(repositoryId);
+      }
+      return next;
+    });
+  }, []);
+
   const toggleGroupList = useCallback((groupId: string, entries: TabEntry[], rect: DOMRect) => {
     if (entries.length === 0) return;
     if (openGroupId === groupId) {
@@ -159,8 +185,8 @@ function TabBar(props: TabBarProps) {
     }
     setGroupListAnchorLeft(rect.left);
     setOpenGroupId(groupId);
-    void onWorktreeMenuOpen(getListRowCount(entries));
-  }, [closeGroupList, onWorktreeMenuOpen, openGroupId]);
+    void onWorktreeMenuOpen(getListRowCount(entries, expandedRepositories));
+  }, [closeGroupList, expandedRepositories, onWorktreeMenuOpen, openGroupId]);
 
   const handleListTabContextMenu = useCallback((index: number, rect: DOMRect) => {
     setOpenGroupId(null);
@@ -408,7 +434,7 @@ function TabBar(props: TabBarProps) {
 
   const renderTab = (tab: EditorWindow, originalIndex: number) => (
     <Tab
-      key={`${tab.bundle_id}:${tab.id}`}
+      key={runtimeWindowKey(tab)}
       name={tab.name}
       isActive={originalIndex === activeIndex}
       isDragging={originalIndex === draggedIndex}
@@ -603,6 +629,7 @@ function TabBar(props: TabBarProps) {
           tabColors={tabColors}
           showBranch={showBranch !== false}
           anchorLeft={groupListAnchorLeft}
+          expandedRepositories={expandedRepositories}
           onTabClick={handleTabClick}
           onCloseTab={handleCloseTab}
           onRequestClose={closeGroupList}
@@ -613,6 +640,7 @@ function TabBar(props: TabBarProps) {
           onDragOver={handleDragOver}
           onDrop={handleDrop}
           onRowCountChange={onWorktreeMenuOpen}
+          onToggleRepository={toggleRepositoryExpansion}
         />
       )}
 

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -2,9 +2,10 @@ import { useState, useCallback, useRef, useMemo, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import Tab from "./Tab";
 import WorktreeTab from "./WorktreeTab";
+import GroupTabList from "./GroupTabList";
 import ColorPicker from "./ColorPicker";
 import AddTabMenu from "./AddTabMenu";
-import type { EditorWindow, ClaudeStatus, HistoryEntry, GroupDefinition, GroupAssignment, TabColorMap } from "../types/editor";
+import type { EditorWindow, ClaudeStatus, HistoryEntry, GroupDefinition, GroupAssignment, TabColorMap, TabLayout } from "../types/editor";
 import { getWindowScopedValue, legacyWindowKey, projectPathMatchesWindow, repositoryColorKey, windowKey } from "../utils/store";
 import { getColorById } from "../constants/tabColors";
 import { getInheritedRepositoryGroupId, groupRepositoryTabs, type TabEntry } from "../utils/repositoryTabs";
@@ -21,6 +22,7 @@ interface TabBarProps {
   tabColors?: TabColorMap;
   onColorChange?: (windowKey: string, colorId: string | null) => void;
   showBranch?: boolean;
+  tabLayout: TabLayout;
   history: HistoryEntry[];
   showAddMenu: boolean;
   onAddMenuOpen: () => void;
@@ -58,8 +60,10 @@ const getClaudeStatusForTab = (tab: EditorWindow, statuses?: Record<string, Clau
   return undefined;
 };
 
+const getListRowCount = (entries: TabEntry[]) => groupRepositoryTabs(entries).length;
+
 function TabBar(props: TabBarProps) {
-  const { tabs, activeIndex, onTabClick, onNewTab, onCloseTab, onReorder, onReorderByVisual, claudeStatuses, tabColors, onColorChange, showBranch, history, showAddMenu, onAddMenuOpen, onAddMenuClose, onHistorySelect, onHistoryClear, onColorPickerOpen, onColorPickerClose, groups, groupAssignments, collapsedGroups, onAddGroup, onUpdateGroup, onDeleteGroup, onAssignTabsToGroup, onUnassignTabsFromGroup, onToggleGroupCollapse, onReorderGroups, groupColors, onSetGroupColor, onTabContextMenuOpen, onTabContextMenuClose, onWorktreeMenuOpen, onWorktreeMenuClose } = props;
+  const { tabs, activeIndex, onTabClick, onNewTab, onCloseTab, onReorder, onReorderByVisual, claudeStatuses, tabColors, onColorChange, showBranch, tabLayout, history, showAddMenu, onAddMenuOpen, onAddMenuClose, onHistorySelect, onHistoryClear, onColorPickerOpen, onColorPickerClose, groups, groupAssignments, collapsedGroups, onAddGroup, onUpdateGroup, onDeleteGroup, onAssignTabsToGroup, onUnassignTabsFromGroup, onToggleGroupCollapse, onReorderGroups, groupColors, onSetGroupColor, onTabContextMenuOpen, onTabContextMenuClose, onWorktreeMenuOpen, onWorktreeMenuClose } = props;
   const { t } = useTranslation();
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
   const [colorPickerTarget, setColorPickerTarget] = useState<{ key: string; currentColorId: string | null } | null>(null);
@@ -73,6 +77,8 @@ function TabBar(props: TabBarProps) {
   const [newGroupInput, setNewGroupInput] = useState<string | null>(null);
   const [groupColorPickerTarget, setGroupColorPickerTarget] = useState<string | null>(null);
   const [groupColorPickerAnchorLeft, setGroupColorPickerAnchorLeft] = useState<number>(0);
+  const [openGroupId, setOpenGroupId] = useState<string | null>(null);
+  const [groupListAnchorLeft, setGroupListAnchorLeft] = useState(8);
   const containerRef = useRef<HTMLDivElement>(null);
   const tabsWrapperRef = useRef<HTMLDivElement>(null);
   const addButtonRef = useRef<HTMLButtonElement>(null);
@@ -138,6 +144,38 @@ function TabBar(props: TabBarProps) {
       rect,
     });
   }, [onTabContextMenuOpen]);
+
+  const closeGroupList = useCallback(() => {
+    if (openGroupId === null) return;
+    setOpenGroupId(null);
+    void onWorktreeMenuClose();
+  }, [onWorktreeMenuClose, openGroupId]);
+
+  const toggleGroupList = useCallback((groupId: string, entries: TabEntry[], rect: DOMRect) => {
+    if (entries.length === 0) return;
+    if (openGroupId === groupId) {
+      closeGroupList();
+      return;
+    }
+    setGroupListAnchorLeft(rect.left);
+    setOpenGroupId(groupId);
+    void onWorktreeMenuOpen(getListRowCount(entries));
+  }, [closeGroupList, onWorktreeMenuOpen, openGroupId]);
+
+  const handleListTabContextMenu = useCallback((index: number, rect: DOMRect) => {
+    setOpenGroupId(null);
+    void handleTabContextMenu(index, rect);
+  }, [handleTabContextMenu]);
+
+  const handleListRepositoryContextMenu = useCallback((
+    repositoryId: string,
+    indices: number[],
+    preferredIndex: number,
+    rect: DOMRect,
+  ) => {
+    setOpenGroupId(null);
+    void handleWorktreeContextMenu(repositoryId, indices, preferredIndex, rect);
+  }, [handleWorktreeContextMenu]);
 
   const handleOpenColorPicker = useCallback(async () => {
     if (tabContextMenu && containerRef.current) {
@@ -237,9 +275,12 @@ function TabBar(props: TabBarProps) {
   }, [editingGroupId, editingGroupName, onUpdateGroup]);
 
   const handleGroupDelete = useCallback((groupId: string) => {
+    if (openGroupId === groupId) {
+      setOpenGroupId(null);
+    }
     onDeleteGroup(groupId);
     closeGroupLabelMenu();
-  }, [onDeleteGroup, closeGroupLabelMenu]);
+  }, [openGroupId, onDeleteGroup, closeGroupLabelMenu]);
 
   const handleOpenGroupColorPicker = useCallback(async (groupId: string) => {
     if (groupLabelMenu && containerRef.current) {
@@ -359,6 +400,12 @@ function TabBar(props: TabBarProps) {
     setDraggedIndex(null);
   }, [draggedIndex, groups.length, onReorder, onReorderByVisual, originalToVisual, visualOrder]);
 
+  useEffect(() => {
+    if (tabLayout === "list" || openGroupId === null) return;
+    setOpenGroupId(null);
+    void onWorktreeMenuClose();
+  }, [onWorktreeMenuClose, openGroupId, tabLayout]);
+
   const renderTab = (tab: EditorWindow, originalIndex: number) => (
     <Tab
       key={`${tab.bundle_id}:${tab.id}`}
@@ -409,6 +456,23 @@ function TabBar(props: TabBarProps) {
     );
   });
 
+  const openGroup = openGroupId
+    ? sortedGroups.find((group) => group.id === openGroupId)
+    : undefined;
+  const openGroupTabs = openGroup ? groupedTabsMap.get(openGroup.id) ?? [] : [];
+  const openGroupStatuses = new Map(
+    openGroupTabs.map(({ tab, originalIndex }) => [
+      originalIndex,
+      getClaudeStatusForTab(tab, claudeStatuses),
+    ]),
+  );
+
+  useEffect(() => {
+    if (openGroupId === null || (openGroup && openGroupTabs.length > 0)) return;
+    setOpenGroupId(null);
+    void onWorktreeMenuClose();
+  }, [onWorktreeMenuClose, openGroup, openGroupId, openGroupTabs.length]);
+
   return (
     <div ref={containerRef} style={styles.container}>
       {/* ドラッグ領域を最背面に配置（全体をカバー） */}
@@ -430,6 +494,8 @@ function TabBar(props: TabBarProps) {
         {sortedGroups.map((group, groupIndex) => {
           const groupTabs = groupedTabsMap.get(group.id) || [];
           const isCollapsed = collapsedGroups.has(group.id);
+          const isListOpen = tabLayout === "list" && openGroupId === group.id;
+          const activeGroupEntry = groupTabs.find(({ originalIndex }) => originalIndex === activeIndex);
           const groupColor = getColorById(groupColors[group.id]);
           const groupContainerStyle: React.CSSProperties = {
             ...styles.groupContainer,
@@ -468,6 +534,7 @@ function TabBar(props: TabBarProps) {
                   style={{
                     ...styles.groupLabel,
                     opacity: draggedGroupIndex === groupIndex ? 0.5 : 1,
+                    ...(tabLayout === "list" && activeGroupEntry ? styles.groupLabelActive : {}),
                     ...(groupColor ? {
                       background: toRgba(groupColor.rgb, 0.2),
                       color: groupColor.hex,
@@ -476,23 +543,39 @@ function TabBar(props: TabBarProps) {
                   draggable
                   onDragStart={(e) => handleGroupDragStart(e, groupIndex)}
                   onDragEnd={handleGroupDragEnd}
-                  onClick={() => onToggleGroupCollapse(group.id)}
+                  onMouseDown={(event) => {
+                    event.stopPropagation();
+                  }}
+                  onClick={(event) => {
+                    if (tabLayout === "horizontal") {
+                      onToggleGroupCollapse(group.id);
+                    } else {
+                      toggleGroupList(group.id, groupTabs, event.currentTarget.getBoundingClientRect());
+                    }
+                  }}
                   onContextMenu={(e) => handleGroupLabelContextMenu(e, group.id)}
-                  onMouseDown={(e) => e.stopPropagation()}
+                  aria-haspopup={tabLayout === "list" ? "menu" : undefined}
+                  aria-expanded={tabLayout === "list" ? isListOpen : undefined}
+                  data-tab-index={activeGroupEntry?.originalIndex}
                 >
                   <span className="group-label-text" style={styles.groupLabelText}>
                     {group.name}
                   </span>
-                  {isCollapsed && (
+                  {(tabLayout === "list" || isCollapsed) && (
                     <span className="group-badge" style={styles.groupBadge}>
                       {groupTabs.length}
+                    </span>
+                  )}
+                  {tabLayout === "list" && (
+                    <span aria-hidden="true" style={styles.groupChevron}>
+                      {isListOpen ? "⌃" : "⌄"}
                     </span>
                   )}
                 </button>
               )}
 
               {/* Group tabs (hidden when collapsed) */}
-              {!isCollapsed && renderRepositoryTabs(groupTabs)}
+              {tabLayout === "horizontal" && !isCollapsed && renderRepositoryTabs(groupTabs)}
             </div>
           );
         })}
@@ -510,6 +593,28 @@ function TabBar(props: TabBarProps) {
           +
         </button>
       </div>
+
+      {tabLayout === "list" && openGroup && openGroupTabs.length > 0 && (
+        <GroupTabList
+          name={openGroup.name}
+          entries={openGroupTabs}
+          activeIndex={activeIndex}
+          statuses={openGroupStatuses}
+          tabColors={tabColors}
+          showBranch={showBranch !== false}
+          anchorLeft={groupListAnchorLeft}
+          onTabClick={handleTabClick}
+          onCloseTab={handleCloseTab}
+          onRequestClose={closeGroupList}
+          onTabContextMenu={handleListTabContextMenu}
+          onRepositoryContextMenu={handleListRepositoryContextMenu}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+          onDragOver={handleDragOver}
+          onDrop={handleDrop}
+          onRowCountChange={onWorktreeMenuOpen}
+        />
+      )}
 
       {colorPickerTarget && (
         <ColorPicker
@@ -759,6 +864,14 @@ const styles: Record<string, React.CSSProperties> = {
     whiteSpace: "nowrap" as const,
     flexShrink: 0,
     marginLeft: "2px",
+  },
+  groupLabelActive: {
+    borderBottom: "2px solid #007aff",
+    color: "#ffffff",
+  },
+  groupChevron: {
+    color: "rgba(255, 255, 255, 0.55)",
+    fontSize: "11px",
   },
   groupLabelText: {
     maxWidth: "80px",

--- a/src/components/WorktreeTab.tsx
+++ b/src/components/WorktreeTab.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { getColorById } from "../constants/tabColors";
 import { EDITOR_DISPLAY_NAMES, type ClaudeStatus } from "../types/editor";
 import type { TabEntry } from "../utils/repositoryTabs";
+import { runtimeWindowKey } from "../utils/store";
 
 interface WorktreeTabProps {
   name: string;
@@ -164,7 +165,7 @@ function WorktreeTab({
             const branchName = tab.branch || tab.name || t("app.untitled");
             const rowActive = originalIndex === activeIndex;
             return (
-              <div key={`${tab.bundle_id}:${tab.id}`} style={styles.row}>
+              <div key={runtimeWindowKey(tab)} style={styles.row}>
                 <button
                   type="button"
                   role="menuitem"

--- a/src/hooks/useAppLifecycle.test.ts
+++ b/src/hooks/useAppLifecycle.test.ts
@@ -11,6 +11,10 @@ import { useAppLifecycle } from "./useAppLifecycle";
 let activeMockStore: ReturnType<typeof createMockStore>;
 vi.mock("../utils/store", () => ({
   getStore: () => Promise.resolve(activeMockStore),
+  loadTabLayout: async () => {
+    const layout = await activeMockStore.get("settings:tabLayout");
+    return layout === "list" ? "list" : "horizontal";
+  },
 }));
 
 type ListenHandler = (event: { payload: unknown }) => void;
@@ -203,6 +207,21 @@ describe("useAppLifecycle", () => {
       await waitFor(() => {
         expect(result.current.showBranch).toBe(false);
       });
+    });
+
+    it("loads the tab layout and applies later changes", async () => {
+      const { result, listeners } = setup({ "settings:tabLayout": "list" });
+
+      await waitFor(() => {
+        expect(result.current.tabLayout).toBe("list");
+        expect(listeners.has("tab-layout-changed")).toBe(true);
+      });
+
+      act(() => {
+        listeners.get("tab-layout-changed")?.({ payload: "horizontal" });
+      });
+
+      expect(result.current.tabLayout).toBe("horizontal");
     });
   });
 

--- a/src/hooks/useAppLifecycle.ts
+++ b/src/hooks/useAppLifecycle.ts
@@ -6,7 +6,8 @@ import { currentMonitor, primaryMonitor } from "@tauri-apps/api/window";
 import { useTranslation } from "react-i18next";
 import { TAB_BAR_HEIGHT, ALL_EDITOR_BUNDLE_IDS } from "../types/editor";
 import type { AppActivationPayload } from "../types/editor";
-import { getStore } from "../utils/store";
+import type { TabLayout } from "../types/editor";
+import { getStore, loadTabLayout } from "../utils/store";
 
 interface UseAppLifecycleParams {
   fetchWindowsRef: MutableRefObject<() => Promise<number>>;
@@ -26,6 +27,7 @@ interface UseAppLifecycleReturn {
   handlePermissionGranted: () => void;
   handleOnboardingComplete: (dontShowAgain: boolean) => Promise<void>;
   showBranch: boolean;
+  tabLayout: TabLayout;
   resizeTabBar: () => Promise<void>;
   handleColorPickerOpen: () => Promise<void>;
   handleColorPickerClose: () => Promise<void>;
@@ -63,6 +65,7 @@ export function useAppLifecycle({
   const [hasAccessibilityPermission, setHasAccessibilityPermission] = useState<boolean | null>(null);
   const [onboardingCompleted, setOnboardingCompleted] = useState<boolean | null>(null);
   const [showBranch, setShowBranch] = useState(true);
+  const [tabLayout, setTabLayout] = useState<TabLayout>("horizontal");
   const isInitializedRef = useRef(false);
   const lastMonitorKeyRef = useRef<string | null>(null);
 
@@ -79,6 +82,7 @@ export function useAppLifecycle({
         if (savedBranch !== null && savedBranch !== undefined) {
           setShowBranch(savedBranch);
         }
+        setTabLayout(await loadTabLayout());
         const savedLang = await store.get<string>("language");
         if (savedLang && savedLang !== i18n.language) {
           await i18n.changeLanguage(savedLang);
@@ -88,6 +92,16 @@ export function useAppLifecycle({
       }
     };
     init();
+  }, []);
+
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    void listen<TabLayout>("tab-layout-changed", (event) => {
+      setTabLayout(event.payload === "list" ? "list" : "horizontal");
+    }).then((cleanup) => {
+      unlisten = cleanup;
+    });
+    return () => unlisten?.();
   }, []);
 
   // Update tray menu when language changes
@@ -433,6 +447,7 @@ export function useAppLifecycle({
     handlePermissionGranted,
     handleOnboardingComplete,
     showBranch,
+    tabLayout,
     resizeTabBar,
     handleColorPickerOpen,
     handleColorPickerClose: handleOverlayClose,

--- a/src/hooks/useEditorWindows.test.ts
+++ b/src/hooks/useEditorWindows.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import type { EditorWindow, EditorState, GroupAssignment, GroupDefinition, TabColorMap } from "../types/editor";
+import type { EditorWindow, GroupAssignment, GroupDefinition, TabColorMap, WindowsSnapshot } from "../types/editor";
 import { useEditorWindows } from "./useEditorWindows";
 
 // Mock store functions directly
@@ -18,7 +18,11 @@ const mockSaveCollapsedGroups = vi.fn().mockResolvedValue(undefined);
 const mockLoadGroupColors = vi.fn<() => Promise<Record<string, string>>>().mockResolvedValue({});
 const mockSaveGroupColors = vi.fn().mockResolvedValue(undefined);
 const mockWindowKey = vi.fn((w: EditorWindow) => `${w.bundle_id}:${w.path || w.name}`);
+const mockRuntimeWindowKey = vi.fn((w: EditorWindow) => w.runtime_id ?? `${w.bundle_id}:${w.id}`);
 const mockSortWindowsByOrder = vi.fn((windows: EditorWindow[], _order: string[]) => [...windows]);
+const mockMigrateResolvedWindowKeys = vi.fn(
+  (order: string[], _current: EditorWindow[], _next: EditorWindow[]) => [...order],
+);
 
 vi.mock("../utils/store", () => ({
   loadTabOrder: (...args: unknown[]) => mockLoadTabOrder(...(args as [])),
@@ -34,6 +38,9 @@ vi.mock("../utils/store", () => ({
   loadGroupColors: (...args: unknown[]) => mockLoadGroupColors(...(args as [])),
   saveGroupColors: (...args: unknown[]) => mockSaveGroupColors(...args),
   windowKey: (w: EditorWindow) => mockWindowKey(w),
+  runtimeWindowKey: (w: EditorWindow) => mockRuntimeWindowKey(w),
+  migrateResolvedWindowKeys: (order: string[], current: EditorWindow[], next: EditorWindow[]) =>
+    mockMigrateResolvedWindowKeys(order, current, next),
   sortWindowsByOrder: (windows: EditorWindow[], order: string[]) => mockSortWindowsByOrder(windows, order),
 }));
 
@@ -92,6 +99,10 @@ describe("useEditorWindows", () => {
     mockLoadGroupColors.mockClear().mockResolvedValue({});
     mockSaveGroupColors.mockClear().mockResolvedValue(undefined);
     mockSortWindowsByOrder.mockClear().mockImplementation((windows) => [...windows]);
+    mockRuntimeWindowKey.mockClear().mockImplementation(
+      (window) => window.runtime_id ?? `${window.bundle_id}:${window.id}`,
+    );
+    mockMigrateResolvedWindowKeys.mockClear().mockImplementation((order) => [...order]);
   });
 
   it("starts with empty windows and activeIndex 0", () => {
@@ -115,7 +126,7 @@ describe("useEditorWindows", () => {
 
       expect(mockLoadTabOrder).toHaveBeenCalledOnce();
       expect(mockLoadTabColors).toHaveBeenCalledOnce();
-      expect(invoke).toHaveBeenCalledWith("get_all_editor_windows");
+      expect(invoke).toHaveBeenCalledWith("get_windows_snapshot");
       expect(result.current.windows).toHaveLength(2);
     });
 
@@ -173,7 +184,7 @@ describe("useEditorWindows", () => {
         await result.current.refreshWindows();
       });
 
-      expect(invoke).toHaveBeenCalledWith("get_all_editor_windows");
+      expect(invoke).toHaveBeenCalledWith("get_windows_snapshot");
       expect(result.current.windows).toHaveLength(1);
     });
 
@@ -246,7 +257,7 @@ describe("useEditorWindows", () => {
       const first = makeWindow({ id: 1, name: "project", path: "/worktrees/one/project" });
       const reopened = makeWindow({ id: 2, name: "project", path: "/worktrees/one/project" });
       vi.mocked(invoke).mockResolvedValue([first]);
-      const { result } = setup();
+      const { result, params } = setup();
 
       await act(async () => {
         await result.current.refreshWindows();
@@ -258,6 +269,40 @@ describe("useEditorWindows", () => {
       });
 
       expect(result.current.windows[0].id).toBe(2);
+      expect(params.addToHistory).not.toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ path: first.path })]),
+      );
+    });
+
+    it("persists the tab order when a runtime-only window resolves to a path", async () => {
+      const unresolved = makeWindow({
+        id: 1,
+        runtime_id: "cursor:42",
+        name: "project",
+        path: "",
+      });
+      const resolved = makeWindow({
+        id: 1,
+        runtime_id: "cursor:42",
+        name: "project",
+        path: "/worktrees/two/project",
+      });
+      mockLoadTabOrder.mockResolvedValue(["runtime-order-key"]);
+      vi.mocked(invoke).mockResolvedValue([unresolved]);
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.refreshWindows();
+      });
+
+      mockSaveTabOrder.mockClear();
+      mockMigrateResolvedWindowKeys.mockReturnValue(["resolved-order-key"]);
+      vi.mocked(invoke).mockResolvedValue([resolved]);
+      await act(async () => {
+        await result.current.refreshWindows();
+      });
+
+      expect(mockSaveTabOrder).toHaveBeenCalledWith(["resolved-order-key"]);
     });
   });
 
@@ -274,13 +319,13 @@ describe("useEditorWindows", () => {
         await result.current.refreshWindows();
       });
 
-      // Mock get_editor_state to return beta as active
-      const editorState: EditorState = {
-        is_active: true,
+      const snapshot: WindowsSnapshot = {
+        revision: 1,
         windows: [win1, win2],
-        active_index: 1,
+        active_id: win2.id,
+        source: "test",
       };
-      vi.mocked(invoke).mockResolvedValue(editorState);
+      vi.mocked(invoke).mockResolvedValue(snapshot);
 
       await act(async () => {
         await result.current.syncActiveTab();
@@ -308,12 +353,13 @@ describe("useEditorWindows", () => {
       });
 
       // Immediately try to sync — should be debounced
-      const editorState: EditorState = {
-        is_active: true,
+      const snapshot: WindowsSnapshot = {
+        revision: 1,
         windows: [win1, win2],
-        active_index: 0,
+        active_id: win1.id,
+        source: "test",
       };
-      vi.mocked(invoke).mockResolvedValue(editorState);
+      vi.mocked(invoke).mockResolvedValue(snapshot);
 
       await act(async () => {
         await result.current.syncActiveTab();
@@ -544,6 +590,37 @@ describe("useEditorWindows", () => {
     it("sets up windows:snapshot listener", async () => {
       const { listeners } = setup();
       await waitFor(() => expect(listeners.has("windows:snapshot")).toBe(true));
+    });
+
+    it("ignores an older snapshot revision", async () => {
+      const current = makeWindow({ id: 1, name: "current" });
+      const stale = makeWindow({ id: 2, name: "stale" });
+      const snapshot: WindowsSnapshot = {
+        revision: 2,
+        windows: [current],
+        active_id: current.id,
+        source: "test",
+      };
+      vi.mocked(invoke).mockResolvedValue(snapshot);
+      const { result, listeners } = setup();
+
+      await act(async () => {
+        await result.current.fetchWindows();
+      });
+      await waitFor(() => expect(listeners.has("windows:snapshot")).toBe(true));
+
+      act(() => {
+        listeners.get("windows:snapshot")!({
+          payload: {
+            revision: 1,
+            windows: [stale],
+            active_id: stale.id,
+            source: "test",
+          },
+        });
+      });
+
+      expect(result.current.windows[0].name).toBe("current");
     });
 
     it("cleans up listeners on unmount", async () => {

--- a/src/hooks/useEditorWindows.ts
+++ b/src/hooks/useEditorWindows.ts
@@ -5,7 +5,7 @@ import { getCurrentWindow, PhysicalPosition } from "@tauri-apps/api/window";
 import { ask } from "@tauri-apps/plugin-dialog";
 import type { TFunction } from "i18next";
 import { TAB_BAR_HEIGHT, ALL_EDITOR_BUNDLE_IDS } from "../types/editor";
-import type { EditorWindow, EditorState, GroupDefinition, GroupAssignment, TabColorMap } from "../types/editor";
+import type { EditorWindow, WindowsSnapshot, GroupDefinition, GroupAssignment, TabColorMap } from "../types/editor";
 import {
   loadTabOrder,
   loadTabColors,
@@ -21,6 +21,8 @@ import {
   saveCollapsedGroups,
   loadGroupColors,
   saveGroupColors,
+  migrateResolvedWindowKeys,
+  runtimeWindowKey,
 } from "../utils/store";
 
 interface UseEditorWindowsParams {
@@ -70,15 +72,23 @@ function editorWindowListsDiffer(next: EditorWindow[], current: EditorWindow[]):
   return next.length !== current.length || next.some((window, index) => {
     const previous = current[index];
     return !previous ||
-      previous.id !== window.id ||
+      runtimeWindowKey(previous) !== runtimeWindowKey(window) ||
       previous.name !== window.name ||
       previous.path !== window.path ||
       previous.branch !== window.branch ||
       previous.repository_id !== window.repository_id ||
       previous.repository_name !== window.repository_name ||
       previous.bundle_id !== window.bundle_id ||
-      previous.editor_name !== window.editor_name;
+      previous.editor_name !== window.editor_name ||
+      previous.resolution !== window.resolution;
   });
+}
+
+function normalizeSnapshot(payload: WindowsSnapshot | EditorWindow[]): WindowsSnapshot {
+  if (Array.isArray(payload)) {
+    return { revision: 0, windows: payload, active_id: null, source: "legacy" };
+  }
+  return payload;
 }
 
 export function useEditorWindows({
@@ -103,6 +113,7 @@ export function useEditorWindows({
   const tabOrderRef = useRef<string[]>([]);
   const orderLoadedRef = useRef(false);
   const lastTabClickTimeRef = useRef<number>(0);
+  const lastSnapshotRevisionRef = useRef<number>(-1);
 
   // Keep refs in sync with state
   useEffect(() => {
@@ -120,7 +131,24 @@ export function useEditorWindows({
         orderLoadedRef.current = true;
       }
 
-      const result = await invoke<EditorWindow[]>("get_all_editor_windows");
+      const snapshot = normalizeSnapshot(
+        await invoke<WindowsSnapshot | EditorWindow[]>("get_windows_snapshot"),
+      );
+      void invoke("request_windows_refresh");
+      lastSnapshotRevisionRef.current = Math.max(
+        lastSnapshotRevisionRef.current,
+        snapshot.revision,
+      );
+      const result = snapshot.windows;
+      const migratedOrder = migrateResolvedWindowKeys(
+        tabOrderRef.current,
+        windowsRef.current,
+        result,
+      );
+      if (migratedOrder.some((key, index) => key !== tabOrderRef.current[index])) {
+        void saveTabOrder(migratedOrder);
+      }
+      tabOrderRef.current = migratedOrder;
       const sorted = sortWindowsByOrder(result, tabOrderRef.current);
       const newOrder = sorted.map((w) => windowKey(w));
       const orderChanged =
@@ -139,7 +167,7 @@ export function useEditorWindows({
           return;
         }
 
-        const newKeys = new Set(sorted.map((w) => windowKey(w)));
+        const newKeys = new Set(sorted.map(windowKey));
         const disappeared = currentWindows.filter(
           (w) => !newKeys.has(windowKey(w)) && w.path
         );
@@ -164,13 +192,14 @@ export function useEditorWindows({
     }
 
     try {
-      const bundleId = currentBundleIdRef.current ?? null;
-      const state = await invoke<EditorState>("get_editor_state", { bundle_id: bundleId });
+      const snapshot = normalizeSnapshot(
+        await invoke<WindowsSnapshot | EditorWindow[]>("get_windows_snapshot"),
+      );
 
-      if (state.active_index !== null && state.windows.length > 0) {
-        const frontmost = state.windows[state.active_index];
+      if (snapshot.active_id !== null && snapshot.windows.length > 0) {
+        const frontmost = snapshot.windows.find((window) => window.id === snapshot.active_id);
         const sortedIndex = windowsRef.current.findIndex(
-          (w) => w.id === frontmost?.id
+          (w) => runtimeWindowKey(w) === (frontmost ? runtimeWindowKey(frontmost) : "")
         );
         if (sortedIndex >= 0 && sortedIndex !== activeIndexRef.current) {
           setActiveIndex(sortedIndex);
@@ -288,7 +317,7 @@ export function useEditorWindows({
     // Find new active index
     const activeWindow = currentWindows[activeIndexRef.current];
     const newActiveIndex = activeWindow
-      ? newWindows.findIndex((w) => w.id === activeWindow.id)
+      ? newWindows.findIndex((w) => runtimeWindowKey(w) === runtimeWindowKey(activeWindow))
       : 0;
 
     setWindows(newWindows);
@@ -434,7 +463,24 @@ export function useEditorWindows({
         orderLoadedRef.current = true;
       }
 
-      const result = await invoke<EditorWindow[]>("get_all_editor_windows");
+      const snapshot = normalizeSnapshot(
+        await invoke<WindowsSnapshot | EditorWindow[]>("get_windows_snapshot"),
+      );
+      void invoke("request_windows_refresh");
+      const result = snapshot.windows;
+      lastSnapshotRevisionRef.current = Math.max(
+        lastSnapshotRevisionRef.current,
+        snapshot.revision,
+      );
+      const migratedOrder = migrateResolvedWindowKeys(
+        tabOrderRef.current,
+        windowsRef.current,
+        result,
+      );
+      if (migratedOrder.some((key, index) => key !== tabOrderRef.current[index])) {
+        void saveTabOrder(migratedOrder);
+      }
+      tabOrderRef.current = migratedOrder;
       const sorted = sortWindowsByOrder(result, tabOrderRef.current);
       tabOrderRef.current = sorted.map((w) => windowKey(w));
 
@@ -568,11 +614,7 @@ export function useEditorWindows({
       });
       cleanupFns.push(unlistenWindowFocus);
 
-      const unlistenSnapshot = await listen<{
-        windows: EditorWindow[];
-        active_id: number | null;
-        source: string;
-      }>("windows:snapshot", (event) => {
+      const unlistenSnapshot = await listen<WindowsSnapshot>("windows:snapshot", (event) => {
         if (!isMounted) return;
 
         if (!orderLoadedRef.current) {
@@ -581,6 +623,20 @@ export function useEditorWindows({
           return;
         }
 
+        if (event.payload.revision <= lastSnapshotRevisionRef.current) {
+          return;
+        }
+        lastSnapshotRevisionRef.current = event.payload.revision;
+
+        const migratedOrder = migrateResolvedWindowKeys(
+          tabOrderRef.current,
+          windowsRef.current,
+          event.payload.windows,
+        );
+        if (migratedOrder.some((key, index) => key !== tabOrderRef.current[index])) {
+          void saveTabOrder(migratedOrder);
+        }
+        tabOrderRef.current = migratedOrder;
         const sorted = sortWindowsByOrder(event.payload.windows, tabOrderRef.current);
         const newOrder = sorted.map((w) => windowKey(w));
         const orderChanged =
@@ -594,7 +650,7 @@ export function useEditorWindows({
         const windowsChanged = editorWindowListsDiffer(sorted, currentWindows);
 
         if (windowsChanged) {
-          const newKeys = new Set(sorted.map((w) => windowKey(w)));
+          const newKeys = new Set(sorted.map(windowKey));
           const disappeared = currentWindows.filter(
             (w) => !newKeys.has(windowKey(w)) && w.path
           );

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -35,6 +35,14 @@
     "autostartDescription": "Automatically launch the app when your PC starts",
     "showBranchLabel": "Show Git Branch",
     "showBranchDescription": "Display Git branch name on tabs",
+    "tabLayoutLabel": "Tab Layout",
+    "tabLayoutDescription": "Choose how groups are displayed in the tab bar",
+    "tabLayout": {
+      "horizontal": "Horizontal",
+      "horizontalDescription": "Arrange tabs and groups horizontally",
+      "list": "List",
+      "listDescription": "Show group tabs in a list below the group"
+    },
     "version": "Version",
     "checkingUpdate": "Checking for updates...",
     "updateAvailable": "v{{version}} available",
@@ -75,6 +83,7 @@
     "daysAgo": "{{count}}d ago"
   },
   "group": {
+    "tabList": "{{name}} tabs",
     "assignToGroup": "Assign to Group",
     "createNew": "Create New Group",
     "newGroupPlaceholder": "Group name",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -35,6 +35,14 @@
     "autostartDescription": "PCの起動時にアプリを自動的に起動します",
     "showBranchLabel": "Gitブランチ名を表示",
     "showBranchDescription": "タブにGitブランチ名を表示します",
+    "tabLayoutLabel": "タブの表示形式",
+    "tabLayoutDescription": "タブバーでグループを表示する方法を選択します",
+    "tabLayout": {
+      "horizontal": "横並び",
+      "horizontalDescription": "タブとグループを横方向に並べます",
+      "list": "リスト",
+      "listDescription": "グループの下にタブを一覧表示します"
+    },
     "version": "バージョン",
     "checkingUpdate": "更新を確認中...",
     "updateAvailable": "v{{version}} が利用可能",
@@ -75,6 +83,7 @@
     "daysAgo": "{{count}}日前"
   },
   "group": {
+    "tabList": "{{name}}のタブ",
     "assignToGroup": "グループに割り当て",
     "createNew": "新規グループ作成",
     "newGroupPlaceholder": "グループ名",

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -8,6 +8,7 @@ vi.mock("@tauri-apps/api/core", () => ({
 // ---- @tauri-apps/api/event ----
 vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn().mockResolvedValue(() => {}),
+  emit: vi.fn().mockResolvedValue(undefined),
 }));
 
 // ---- @tauri-apps/api/window ----
@@ -18,6 +19,8 @@ const mockAppWindow = {
   setMaxSize: vi.fn().mockResolvedValue(undefined),
   setPosition: vi.fn().mockResolvedValue(undefined),
   onMoved: vi.fn().mockResolvedValue(() => {}),
+  setTitle: vi.fn().mockResolvedValue(undefined),
+  close: vi.fn().mockResolvedValue(undefined),
 };
 
 vi.mock("@tauri-apps/api/window", () => ({

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -1,6 +1,8 @@
 // Tab bar height (px)
 export const TAB_BAR_HEIGHT = 36;
 
+export type TabLayout = "horizontal" | "list";
+
 export interface EditorWindow {
   id: number;
   name: string;

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -4,6 +4,7 @@ export const TAB_BAR_HEIGHT = 36;
 export type TabLayout = "horizontal" | "list";
 
 export interface EditorWindow {
+  runtime_id?: string;
   id: number;
   name: string;
   path: string;
@@ -12,6 +13,14 @@ export interface EditorWindow {
   repository_name?: string;
   bundle_id: string;
   editor_name: string;
+  resolution?: "exact" | "inferred" | "unresolved";
+}
+
+export interface WindowsSnapshot {
+  revision: number;
+  windows: EditorWindow[];
+  active_id: number | null;
+  source: string;
 }
 
 export interface HistoryEntry {

--- a/src/utils/store.test.ts
+++ b/src/utils/store.test.ts
@@ -7,6 +7,8 @@ import {
   normalizeProjectPath,
   projectPathMatchesWindow,
   repositoryColorKey,
+  migrateResolvedWindowKeys,
+  runtimeWindowKey,
   windowKey,
   sortWindowsByOrder,
   UNIFIED_ORDER_KEY,
@@ -51,9 +53,27 @@ describe("windowKey", () => {
     expect(windowKey(a)).not.toBe(windowKey(b));
   });
 
-  it("falls back to the legacy key when path is unavailable", () => {
-    const w = makeWindow({ name: "proj", path: "" });
-    expect(windowKey(w)).toBe(legacyWindowKey(w));
+  it("uses runtime identity when path is unavailable", () => {
+    const w = makeWindow({ name: "proj", path: "", runtime_id: "cursor:42" });
+    expect(windowKey(w)).toBe("com.microsoft.VSCode:runtime:cursor:42");
+  });
+
+  it("keeps same-named unresolved windows distinct", () => {
+    const first = makeWindow({ name: "proj", path: "", runtime_id: "cursor:42" });
+    const second = makeWindow({ name: "proj", path: "", runtime_id: "cursor:43" });
+    expect(windowKey(first)).not.toBe(windowKey(second));
+  });
+});
+
+describe("migrateResolvedWindowKeys", () => {
+  it("replaces a runtime key after the same window resolves to a path", () => {
+    const unresolved = makeWindow({ path: "", runtime_id: "cursor:42" });
+    const resolved = makeWindow({ path: "/worktrees/two/project", runtime_id: "cursor:42" });
+
+    expect(
+      migrateResolvedWindowKeys([windowKey(unresolved)], [unresolved], [resolved]),
+    ).toEqual([windowKey(resolved)]);
+    expect(runtimeWindowKey(unresolved)).toBe(runtimeWindowKey(resolved));
   });
 });
 
@@ -125,6 +145,16 @@ describe("sortWindowsByOrder", () => {
   it("handles empty order — all windows sorted alphabetically", () => {
     const result = sortWindowsByOrder([w2, w1], []);
     expect(result.map((w) => w.name)).toEqual(["alpha", "beta"]);
+  });
+
+  it("sorts same-named resolved windows by their stable path", () => {
+    const first = makeWindow({ name: "project", path: "/projects/project" });
+    const second = makeWindow({ name: "project", path: "/worktrees/project" });
+    const result = sortWindowsByOrder([second, first], []);
+    expect(result.map((window) => window.path)).toEqual([
+      "/projects/project",
+      "/worktrees/project",
+    ]);
   });
 
   it("does not mutate the original array", () => {

--- a/src/utils/store.test.ts
+++ b/src/utils/store.test.ts
@@ -11,6 +11,7 @@ import {
   sortWindowsByOrder,
   UNIFIED_ORDER_KEY,
   UNIFIED_COLOR_KEY,
+  TAB_LAYOUT_KEY,
 } from "./store";
 
 // Reset the cached storePromise between tests by re-importing fresh module
@@ -235,6 +236,24 @@ describe("Store functions", () => {
       const { loadTabColors } = await freshImport();
       const result = await loadTabColors();
       expect(result).toEqual({});
+    });
+  });
+
+  describe("loadTabLayout / saveTabLayout", () => {
+    it("defaults invalid or missing values to horizontal", async () => {
+      const { loadTabLayout } = await freshImport();
+      expect(await loadTabLayout()).toBe("horizontal");
+
+      await mockStore.set(TAB_LAYOUT_KEY, "unknown");
+      expect(await loadTabLayout()).toBe("horizontal");
+    });
+
+    it("saves and loads list layout", async () => {
+      const { loadTabLayout, saveTabLayout } = await freshImport();
+      await saveTabLayout("list");
+
+      expect(mockStore.set).toHaveBeenCalledWith(TAB_LAYOUT_KEY, "list");
+      expect(await loadTabLayout()).toBe("list");
     });
   });
 

--- a/src/utils/store.ts
+++ b/src/utils/store.ts
@@ -70,10 +70,36 @@ export function legacyWindowKey(w: EditorWindow): string {
   return `${w.bundle_id}:${w.name}`;
 }
 
-// Unique key for a window in the unified tab bar (handles worktrees with the same project name)
+export function runtimeWindowKey(w: EditorWindow): string {
+  return w.runtime_id ?? `${w.bundle_id}:${w.id}`;
+}
+
 export function windowKey(w: EditorWindow): string {
-  const identity = w.path ? normalizeProjectPath(w.path) : w.name;
+  const identity = w.path
+    ? normalizeProjectPath(w.path)
+    : `runtime:${runtimeWindowKey(w)}`;
   return `${w.bundle_id}:${identity}`;
+}
+
+export function migrateResolvedWindowKeys(
+  order: string[],
+  currentWindows: EditorWindow[],
+  nextWindows: EditorWindow[],
+): string[] {
+  const nextByRuntimeId = new Map(
+    nextWindows.map((window) => [runtimeWindowKey(window), window]),
+  );
+  const migrations = new Map<string, string>();
+  for (const current of currentWindows) {
+    const next = nextByRuntimeId.get(runtimeWindowKey(current));
+    if (!next) continue;
+    const currentKey = windowKey(current);
+    const nextKey = windowKey(next);
+    if (currentKey !== nextKey) {
+      migrations.set(currentKey, nextKey);
+    }
+  }
+  return order.map((key) => migrations.get(key) ?? key);
 }
 
 export function repositoryColorKey(repositoryId: string): string {
@@ -107,7 +133,7 @@ export function sortWindowsByOrder(windows: EditorWindow[], order: string[]): Ed
     const indexA = orderMap.get(windowKey(a)) ?? orderMap.get(legacyWindowKey(a)) ?? Infinity;
     const indexB = orderMap.get(windowKey(b)) ?? orderMap.get(legacyWindowKey(b)) ?? Infinity;
     if (indexA === Infinity && indexB === Infinity) {
-      return a.name.localeCompare(b.name);
+      return a.name.localeCompare(b.name) || windowKey(a).localeCompare(windowKey(b));
     }
     return indexA - indexB;
   });

--- a/src/utils/store.ts
+++ b/src/utils/store.ts
@@ -1,6 +1,6 @@
 import { load } from "@tauri-apps/plugin-store";
 import type { Store } from "@tauri-apps/plugin-store";
-import type { EditorWindow, GroupAssignment, GroupDefinition, HistoryEntry, TabColorMap } from "../types/editor";
+import type { EditorWindow, GroupAssignment, GroupDefinition, HistoryEntry, TabColorMap, TabLayout } from "../types/editor";
 
 // Store instance (lazily initialized)
 let storePromise: Promise<Store> | null = null;
@@ -21,6 +21,7 @@ export const GROUPS_DEFINITIONS_KEY = "groups:definitions";
 export const GROUPS_ASSIGNMENTS_KEY = "groups:assignments";
 export const GROUPS_COLLAPSED_KEY = "groups:collapsed";
 export const GROUPS_COLORS_KEY = "groups:colors";
+export const TAB_LAYOUT_KEY = "settings:tabLayout";
 
 // Generic store helpers
 async function loadValue<T>(key: string, defaultValue: T): Promise<T> {
@@ -55,6 +56,11 @@ export const loadCollapsedGroups = () => loadValue<string[]>(GROUPS_COLLAPSED_KE
 export const saveCollapsedGroups = (collapsedIds: string[]) => saveValue(GROUPS_COLLAPSED_KEY, collapsedIds);
 export const loadGroupColors = () => loadValue<Record<string, string>>(GROUPS_COLORS_KEY, {});
 export const saveGroupColors = (colors: Record<string, string>) => saveValue(GROUPS_COLORS_KEY, colors);
+export const loadTabLayout = async (): Promise<TabLayout> => {
+  const layout = await loadValue<unknown>(TAB_LAYOUT_KEY, "horizontal");
+  return layout === "list" ? "list" : "horizontal";
+};
+export const saveTabLayout = (layout: TabLayout) => saveValue(TAB_LAYOUT_KEY, layout);
 
 export function normalizeProjectPath(path: string): string {
   return path.length > 1 ? path.replace(/\/+$/, "") : path;


### PR DESCRIPTION
## Summary
- add horizontal and list layouts for grouped tabs
- show repository worktrees as collapsible rows with scrolling for long lists
- prioritize repository worktree rows above regular tabs in list layout
- keep repository expansion state after tabs close or the list reopens
- resolve Cursor windows against main-process session data so each worktree shows the correct branch
- serialize window refreshes through a versioned registry and preserve stable tab identity and order

## Test plan
- [x] `pnpm test:run` (133 tests)
- [x] `pnpm build`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` (49 tests)
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -A clippy::manual-c-str-literals -D warnings`
- [x] manually verify same-named Cursor worktrees show their actual branches and keep a stable order
- [x] manually verify expanded repository rows remain open after closing a tab

## Known issues
- None
