### PR TITLE
feat: persist tabs and choose editor on reopen

### DIFF
--- a/src-tauri/src/editor.rs
+++ b/src-tauri/src/editor.rs
@@ -3,16 +3,28 @@ use crate::editor_config::{EditorConfig, EDITORS};
 use crate::editor_model::{EditorSession, NativeEditorWindow};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 pub use crate::editor_model::{EditorState, EditorWindow, WorkspaceResolution};
 
 type WindowPathCacheKey = (String, u32, String);
 type WorkspacePathOwnerKey = (String, PathBuf);
+const PENDING_PROJECT_OPEN_TTL: Duration = Duration::from_secs(30);
 
 lazy_static::lazy_static! {
     /// Editor ID + window ID + project name -> full path
     static ref WINDOW_PATH_CACHE: std::sync::Mutex<HashMap<WindowPathCacheKey, PathBuf>> =
         std::sync::Mutex::new(HashMap::new());
+    static ref PENDING_PROJECT_OPENS:
+        std::sync::Mutex<HashMap<String, Vec<PendingProjectOpen>>> =
+        std::sync::Mutex::new(HashMap::new());
+}
+
+#[derive(Clone)]
+struct PendingProjectOpen {
+    path: PathBuf,
+    existing_window_ids: HashSet<u32>,
+    created_at: Instant,
 }
 
 #[derive(Default)]
@@ -150,6 +162,7 @@ fn collect_editor_windows(
         .map(|window| (window.id, window.title.clone(), window.is_frontmost))
         .collect::<Vec<_>>();
     prepare_window_path_resolution(config, &ax_windows, &workspace_state);
+    let pending_resolutions = take_pending_project_open_paths(config, &native_windows);
     let project_window_counts = count_project_windows(config, &ax_windows);
 
     for (window_id, (path, _)) in &session_resolutions {
@@ -182,7 +195,8 @@ fn collect_editor_windows(
                         project_window_counts.get(&name).copied().unwrap_or(1),
                         &workspace_state,
                     )
-                });
+                })
+                .or_else(|| pending_resolutions.get(&window.id).cloned());
             let resolution = session_resolution
                 .map(|(_, resolution)| *resolution)
                 .or_else(|| resolved_path.as_ref().map(|_| WorkspaceResolution::Inferred))
@@ -820,6 +834,139 @@ fn find_zed_cli() -> Option<PathBuf> {
     candidates.into_iter().find(|path| path.is_file())
 }
 
+fn current_editor_window_ids(config: &EditorConfig) -> HashSet<u32> {
+    let Some(pid) = ax_helper::get_pid_by_bundle_id(config.bundle_id) else {
+        return HashSet::new();
+    };
+    ax_helper::get_native_windows_ax(pid, config.bundle_id, config.id == "cursor")
+        .unwrap_or_default()
+        .into_iter()
+        .map(|window| window.id)
+        .collect()
+}
+
+fn project_path_matches_name(path: &Path, project_name: &str) -> bool {
+    if path.file_name().and_then(|name| name.to_str()) == Some(project_name) {
+        return true;
+    }
+    find_git_root(path)
+        .and_then(|root| get_repository_info(&root))
+        .is_some_and(|(_, repository_name)| repository_name == project_name)
+}
+
+fn match_pending_project_opens(
+    config: &EditorConfig,
+    pending_opens: &[PendingProjectOpen],
+    native_windows: &[NativeEditorWindow],
+) -> (HashMap<u32, PathBuf>, HashSet<usize>) {
+    let windows = native_windows
+        .iter()
+        .filter(|window| !window.title.is_empty() && window.title != "Untitled")
+        .map(|window| (window.id, extract_project_name(&window.title, config)))
+        .collect::<Vec<_>>();
+    let mut pending_indices = (0..pending_opens.len()).collect::<Vec<_>>();
+    pending_indices.sort_by_key(|index| {
+        std::cmp::Reverse(pending_opens[*index].existing_window_ids.len())
+    });
+
+    let mut assigned_window_ids = HashSet::new();
+    let mut consumed_pending_indices = HashSet::new();
+    let mut matches = HashMap::new();
+
+    for index in pending_indices {
+        let pending = &pending_opens[index];
+        let candidates = windows
+            .iter()
+            .filter(|(window_id, project_name)| {
+                !pending.existing_window_ids.contains(window_id)
+                    && !assigned_window_ids.contains(window_id)
+                    && project_path_matches_name(&pending.path, project_name)
+            })
+            .collect::<Vec<_>>();
+        if candidates.len() != 1 {
+            continue;
+        }
+
+        let (window_id, project_name) = candidates[0];
+        let has_competing_open = pending_opens
+            .iter()
+            .enumerate()
+            .any(|(other_index, other)| {
+                other_index != index
+                    && !consumed_pending_indices.contains(&other_index)
+                    && other.existing_window_ids == pending.existing_window_ids
+                    && project_path_matches_name(&other.path, project_name)
+            });
+        if has_competing_open {
+            continue;
+        }
+
+        assigned_window_ids.insert(*window_id);
+        consumed_pending_indices.insert(index);
+        matches.insert(*window_id, pending.path.clone());
+    }
+
+    (matches, consumed_pending_indices)
+}
+
+fn register_pending_project_open(
+    config: &EditorConfig,
+    path: &Path,
+    existing_window_ids: HashSet<u32>,
+) {
+    if let Ok(mut pending_by_editor) = PENDING_PROJECT_OPENS.lock() {
+        pending_by_editor
+            .entry(config.id.to_string())
+            .or_default()
+            .push(PendingProjectOpen {
+                path: path.to_path_buf(),
+                existing_window_ids,
+                created_at: Instant::now(),
+            });
+    }
+}
+
+fn take_pending_project_open_paths(
+    config: &EditorConfig,
+    native_windows: &[NativeEditorWindow],
+) -> HashMap<u32, PathBuf> {
+    let pending_opens = match PENDING_PROJECT_OPENS.lock() {
+        Ok(mut pending_by_editor) => pending_by_editor.remove(config.id).unwrap_or_default(),
+        Err(_) => return HashMap::new(),
+    };
+    let now = Instant::now();
+    let pending_opens = pending_opens
+        .into_iter()
+        .filter(|pending| now.duration_since(pending.created_at) <= PENDING_PROJECT_OPEN_TTL)
+        .collect::<Vec<_>>();
+    let (matches, consumed_indices) =
+        match_pending_project_opens(config, &pending_opens, native_windows);
+
+    let remaining = pending_opens
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, pending)| {
+            (!consumed_indices.contains(&index)).then_some(pending)
+        })
+        .collect::<Vec<_>>();
+    if !remaining.is_empty() {
+        if let Ok(mut pending_by_editor) = PENDING_PROJECT_OPENS.lock() {
+            pending_by_editor
+                .entry(config.id.to_string())
+                .or_default()
+                .extend(remaining);
+        }
+    }
+
+    for (window_id, path) in &matches {
+        if let Some(window) = native_windows.iter().find(|window| window.id == *window_id) {
+            let project_name = extract_project_name(&window.title, config);
+            cache_window_path(config.id, *window_id, &project_name, path);
+        }
+    }
+    matches
+}
+
 fn build_project_open_command(
     config: &EditorConfig,
     path: &str,
@@ -847,11 +994,13 @@ pub fn open_project_in_editor(bundle_id: &str, path: &str) -> Result<(), String>
         return Err(format!("Project path does not exist: {}", path));
     }
 
+    let existing_window_ids = current_editor_window_ids(config);
     let zed_cli = (config.id == "zed").then(find_zed_cli).flatten();
     let status = build_project_open_command(config, path, zed_cli.as_deref())?
         .status()
         .map_err(|e| format!("Failed to open project: {}", e))?;
     if status.success() {
+        register_pending_project_open(config, Path::new(path), existing_window_ids);
         Ok(())
     } else {
         Err(format!("Failed to open project in {}", config.display_name))
@@ -877,6 +1026,14 @@ mod tests {
 
     fn native_window(id: u32, title: &str) -> NativeEditorWindow {
         NativeEditorWindow::new("cursor", 10, id, title.to_string(), false, Vec::new())
+    }
+
+    fn pending_open(path: &str, existing_window_ids: &[u32]) -> PendingProjectOpen {
+        PendingProjectOpen {
+            path: PathBuf::from(path),
+            existing_window_ids: existing_window_ids.iter().copied().collect(),
+            created_at: Instant::now(),
+        }
     }
 
     #[test]
@@ -920,6 +1077,66 @@ mod tests {
             command.get_args().collect::<Vec<_>>(),
             ["-a", "Visual Studio Code", "/projects/api"]
         );
+    }
+
+    #[test]
+    fn pending_open_matches_a_new_window_for_vscode_and_cursor() {
+        for (bundle_id, title) in [
+            ("com.microsoft.VSCode", "api — Visual Studio Code"),
+            ("com.todesktop.230313mzl4w4u92", "api — Cursor"),
+        ] {
+            let config = crate::editor_config::get_editor_by_bundle_id(bundle_id).unwrap();
+            let pending = vec![pending_open("/projects/api", &[100])];
+            let windows = vec![native_window(100, title), native_window(200, title)];
+
+            let (matches, consumed) =
+                match_pending_project_opens(config, &pending, &windows);
+
+            assert_eq!(matches[&200], PathBuf::from("/projects/api"));
+            assert_eq!(consumed, HashSet::from([0]));
+        }
+    }
+
+    #[test]
+    fn pending_opens_match_same_named_zed_worktrees_by_new_window_id() {
+        let config =
+            crate::editor_config::get_editor_by_bundle_id("dev.zed.Zed").unwrap();
+        let pending = vec![
+            pending_open("/worktrees/one/project", &[100]),
+            pending_open("/worktrees/two/project", &[100, 200]),
+        ];
+        let windows = vec![
+            native_window(100, "project"),
+            native_window(200, "project"),
+            native_window(300, "project"),
+        ];
+
+        let (matches, consumed) =
+            match_pending_project_opens(config, &pending, &windows);
+
+        assert_eq!(matches[&200], PathBuf::from("/worktrees/one/project"));
+        assert_eq!(matches[&300], PathBuf::from("/worktrees/two/project"));
+        assert_eq!(consumed, HashSet::from([0, 1]));
+    }
+
+    #[test]
+    fn pending_opens_do_not_guess_when_same_named_windows_are_ambiguous() {
+        let config =
+            crate::editor_config::get_editor_by_bundle_id("dev.zed.Zed").unwrap();
+        let pending = vec![
+            pending_open("/worktrees/one/project", &[100]),
+            pending_open("/worktrees/two/project", &[100]),
+        ];
+        let windows = vec![
+            native_window(100, "project"),
+            native_window(200, "project"),
+        ];
+
+        let (matches, consumed) =
+            match_pending_project_opens(config, &pending, &windows);
+
+        assert!(matches.is_empty());
+        assert!(consumed.is_empty());
     }
 
     fn editor_session(id: u32, title: &str, path: Option<&str>) -> EditorSession {

--- a/src-tauri/src/editor.rs
+++ b/src-tauri/src/editor.rs
@@ -790,24 +790,72 @@ pub fn open_new_editor(bundle_id: &str) -> Result<(), String> {
     let config = crate::editor_config::get_editor_by_bundle_id(bundle_id)
         .ok_or_else(|| format!("Unknown editor: {}", bundle_id))?;
 
-    let pid = ax_helper::get_pid_by_bundle_id(config.bundle_id)
-        .ok_or_else(|| format!("Editor not running: {}", config.display_name))?;
+    if let Some(pid) = ax_helper::get_pid_by_bundle_id(config.bundle_id) {
+        return ax_helper::open_new_window_ax(pid);
+    }
 
-    ax_helper::open_new_window_ax(pid)
+    let status = std::process::Command::new("open")
+        .arg("-a")
+        .arg(config.app_name)
+        .status()
+        .map_err(|e| format!("Failed to launch editor: {}", e))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("Failed to launch {}", config.display_name))
+    }
+}
+
+fn find_zed_cli() -> Option<PathBuf> {
+    let mut candidates = vec![
+        PathBuf::from("/usr/local/bin/zed"),
+        PathBuf::from("/opt/homebrew/bin/zed"),
+        PathBuf::from("/Applications/Zed.app/Contents/MacOS/cli"),
+    ];
+    if let Some(home_dir) = std::env::var_os("HOME") {
+        candidates.push(
+            PathBuf::from(home_dir).join("Applications/Zed.app/Contents/MacOS/cli"),
+        );
+    }
+    candidates.into_iter().find(|path| path.is_file())
+}
+
+fn build_project_open_command(
+    config: &EditorConfig,
+    path: &str,
+    zed_cli: Option<&Path>,
+) -> Result<std::process::Command, String> {
+    if config.id == "zed" {
+        let cli = zed_cli.ok_or_else(|| {
+            "Zed CLI not found. Install it from Zed's command palette.".to_string()
+        })?;
+        let mut command = std::process::Command::new(cli);
+        command.arg("-n").arg(path);
+        return Ok(command);
+    }
+
+    let mut command = std::process::Command::new("open");
+    command.arg("-a").arg(config.app_name).arg(path);
+    Ok(command)
 }
 
 /// Open a project directory in a specific editor
 pub fn open_project_in_editor(bundle_id: &str, path: &str) -> Result<(), String> {
     let config = crate::editor_config::get_editor_by_bundle_id(bundle_id)
         .ok_or_else(|| format!("Unknown editor: {}", bundle_id))?;
+    if !Path::new(path).exists() {
+        return Err(format!("Project path does not exist: {}", path));
+    }
 
-    std::process::Command::new("open")
-        .arg("-a")
-        .arg(config.app_name)
-        .arg(path)
-        .spawn()
+    let zed_cli = (config.id == "zed").then(find_zed_cli).flatten();
+    let status = build_project_open_command(config, path, zed_cli.as_deref())?
+        .status()
         .map_err(|e| format!("Failed to open project: {}", e))?;
-    Ok(())
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("Failed to open project in {}", config.display_name))
+    }
 }
 
 /// Close a specific editor window by CGWindowID
@@ -829,6 +877,49 @@ mod tests {
 
     fn native_window(id: u32, title: &str) -> NativeEditorWindow {
         NativeEditorWindow::new("cursor", 10, id, title.to_string(), false, Vec::new())
+    }
+
+    #[test]
+    fn open_project_rejects_a_missing_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let missing = temp.path().join("missing");
+
+        let result =
+            open_project_in_editor("com.microsoft.VSCode", missing.to_str().unwrap());
+
+        assert!(result.unwrap_err().contains("Project path does not exist"));
+    }
+
+    #[test]
+    fn zed_project_command_forces_a_new_window() {
+        let config =
+            crate::editor_config::get_editor_by_bundle_id("dev.zed.Zed").unwrap();
+        let command = build_project_open_command(
+            config,
+            "/projects/word-diary",
+            Some(Path::new("/mock/zed")),
+        )
+        .unwrap();
+
+        assert_eq!(command.get_program(), "/mock/zed");
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            ["-n", "/projects/word-diary"]
+        );
+    }
+
+    #[test]
+    fn vscode_project_command_keeps_the_existing_open_behavior() {
+        let config =
+            crate::editor_config::get_editor_by_bundle_id("com.microsoft.VSCode").unwrap();
+        let command =
+            build_project_open_command(config, "/projects/api", None).unwrap();
+
+        assert_eq!(command.get_program(), "open");
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            ["-a", "Visual Studio Code", "/projects/api"]
+        );
     }
 
     fn editor_session(id: u32, title: &str, path: Option<&str>) -> EditorSession {

--- a/src-tauri/src/editor.rs
+++ b/src-tauri/src/editor.rs
@@ -3,6 +3,8 @@ use crate::editor_config::{EditorConfig, EDITORS};
 use crate::editor_model::{EditorSession, NativeEditorWindow};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Condvar;
 use std::time::{Duration, Instant};
 
 pub use crate::editor_model::{
@@ -12,6 +14,7 @@ pub use crate::editor_model::{
 type WindowPathCacheKey = (String, u32, String);
 type WorkspacePathOwnerKey = (String, PathBuf);
 const PENDING_PROJECT_OPEN_TTL: Duration = Duration::from_secs(30);
+static NEXT_PENDING_PROJECT_OPEN_ID: AtomicU64 = AtomicU64::new(1);
 
 lazy_static::lazy_static! {
     /// Editor ID + window ID + project name -> full path
@@ -20,12 +23,24 @@ lazy_static::lazy_static! {
     static ref PENDING_PROJECT_OPENS:
         std::sync::Mutex<HashMap<String, Vec<PendingProjectOpen>>> =
         std::sync::Mutex::new(HashMap::new());
+    static ref PENDING_PROJECT_OPEN_CHANGED: Condvar = Condvar::new();
+    static ref PENDING_WINDOW_PATHS:
+        std::sync::Mutex<HashMap<WindowPathCacheKey, PendingWindowPath>> =
+        std::sync::Mutex::new(HashMap::new());
 }
 
 #[derive(Clone)]
 struct PendingProjectOpen {
+    request_id: u64,
     path: PathBuf,
     existing_window_ids: HashSet<u32>,
+    created_at: Instant,
+    is_ready: bool,
+}
+
+#[derive(Clone)]
+struct PendingWindowPath {
+    path: PathBuf,
     created_at: Instant,
 }
 
@@ -164,7 +179,6 @@ fn collect_editor_windows(
         .map(|window| (window.id, window.title.clone(), window.is_frontmost))
         .collect::<Vec<_>>();
     prepare_window_path_resolution(config, &ax_windows, &workspace_state);
-    let pending_resolutions = take_pending_project_open_paths(config, &native_windows);
     let project_window_counts = count_project_windows(config, &ax_windows);
 
     for (window_id, (path, _)) in &session_resolutions {
@@ -173,6 +187,36 @@ fn collect_editor_windows(
             cache_window_path(config.id, *window_id, &name, path);
         }
     }
+
+    let mut standard_resolutions = HashMap::new();
+    for window in native_windows
+        .iter()
+        .filter(|window| !window.title.is_empty() && window.title != "Untitled")
+    {
+        if let Some((path, resolution)) = session_resolutions.get(&window.id) {
+            standard_resolutions.insert(window.id, (path.clone(), *resolution));
+            continue;
+        }
+        let name = extract_project_name(&window.title, config);
+        if let Some(path) = resolve_project_path(
+            &name,
+            config.id,
+            pid,
+            window.id,
+            project_window_counts.get(&name).copied().unwrap_or(1),
+            &workspace_state,
+        ) {
+            standard_resolutions.insert(window.id, (path, WorkspaceResolution::Inferred));
+        }
+    }
+    let resolved_paths = standard_resolutions
+        .iter()
+        .map(|(window_id, (path, _))| (*window_id, path.clone()))
+        .collect::<HashMap<_, _>>();
+    acknowledge_resolved_pending_project_open(config, &resolved_paths);
+    let resolved_window_ids = standard_resolutions.keys().copied().collect::<HashSet<_>>();
+    let pending_resolutions =
+        take_pending_project_open_paths(config, &native_windows, &resolved_window_ids);
 
     let active_id = native_windows
         .iter()
@@ -185,21 +229,11 @@ fn collect_editor_windows(
                 return None;
             }
             let name = extract_project_name(&window.title, config);
-            let session_resolution = session_resolutions.get(&window.id);
-            let resolved_path = session_resolution
+            let standard_resolution = standard_resolutions.get(&window.id);
+            let resolved_path = standard_resolution
                 .map(|(path, _)| path.clone())
-                .or_else(|| {
-                    resolve_project_path(
-                        &name,
-                        config.id,
-                        pid,
-                        window.id,
-                        project_window_counts.get(&name).copied().unwrap_or(1),
-                        &workspace_state,
-                    )
-                })
                 .or_else(|| pending_resolutions.get(&window.id).cloned());
-            let resolution = session_resolution
+            let resolution = standard_resolution
                 .map(|(_, resolution)| *resolution)
                 .or_else(|| resolved_path.as_ref().map(|_| WorkspaceResolution::Inferred))
                 .unwrap_or(WorkspaceResolution::Unresolved);
@@ -256,6 +290,9 @@ pub fn get_all_editor_window_snapshot() -> (Vec<EditorWindow>, Option<u32>) {
 pub fn invalidate_path_cache_for_editor(editor_id: &str) {
     if let Ok(mut cache) = WINDOW_PATH_CACHE.lock() {
         cache.retain(|(cached_editor_id, _, _), _| cached_editor_id != editor_id);
+    }
+    if let Ok(mut pending_paths) = PENDING_WINDOW_PATHS.lock() {
+        pending_paths.retain(|(cached_editor_id, _, _), _| cached_editor_id != editor_id);
     }
 }
 
@@ -491,12 +528,71 @@ fn percent_decode(input: &str) -> String {
 }
 
 fn cache_window_path(editor_id: &str, window_id: u32, project_name: &str, path: &Path) {
+    let key = (editor_id.to_string(), window_id, project_name.to_string());
     if let Ok(mut cache) = WINDOW_PATH_CACHE.lock() {
-        cache.insert(
-            (editor_id.to_string(), window_id, project_name.to_string()),
-            path.to_path_buf(),
+        cache.insert(key.clone(), path.to_path_buf());
+    }
+    if let Ok(mut pending_paths) = PENDING_WINDOW_PATHS.lock() {
+        pending_paths.remove(&key);
+    }
+}
+
+fn cache_pending_window_path(
+    editor_id: &str,
+    window_id: u32,
+    project_name: &str,
+    path: &Path,
+) {
+    let key = (editor_id.to_string(), window_id, project_name.to_string());
+    if let Ok(mut cache) = WINDOW_PATH_CACHE.lock() {
+        cache.insert(key.clone(), path.to_path_buf());
+    }
+    if let Ok(mut pending_paths) = PENDING_WINDOW_PATHS.lock() {
+        pending_paths.insert(
+            key,
+            PendingWindowPath {
+                path: path.to_path_buf(),
+                created_at: Instant::now(),
+            },
         );
     }
+}
+
+fn active_pending_window_paths(
+    config: &EditorConfig,
+    ax_windows: &[(u32, String, bool)],
+) -> HashMap<WindowPathCacheKey, PathBuf> {
+    let now = Instant::now();
+    let mut pending_paths = match PENDING_WINDOW_PATHS.lock() {
+        Ok(paths) => paths,
+        Err(_) => return HashMap::new(),
+    };
+    pending_paths.retain(|(editor_id, window_id, project_name), pending| {
+        if editor_id != config.id {
+            return true;
+        }
+        now.duration_since(pending.created_at) <= PENDING_PROJECT_OPEN_TTL
+            && ax_windows.iter().any(|(id, title, _)| {
+                id == window_id && extract_project_name(title, config) == *project_name
+            })
+    });
+    pending_paths
+        .iter()
+        .filter(|((editor_id, _, _), _)| editor_id == config.id)
+        .map(|(key, pending)| (key.clone(), pending.path.clone()))
+        .collect()
+}
+
+fn pending_window_path(key: &WindowPathCacheKey) -> Option<PathBuf> {
+    let now = Instant::now();
+    let mut pending_paths = PENDING_WINDOW_PATHS.lock().ok()?;
+    let is_expired = pending_paths
+        .get(key)
+        .is_some_and(|pending| now.duration_since(pending.created_at) > PENDING_PROJECT_OPEN_TTL);
+    if is_expired {
+        pending_paths.remove(key);
+    }
+    pending_paths.get(key).map(|pending| pending.path.clone())
 }
 
 fn workspace_path_for_document(candidates: &[PathBuf], document_path: &Path) -> Option<PathBuf> {
@@ -541,6 +637,7 @@ fn prepare_window_path_resolution(
     ax_windows: &[(u32, String, bool)],
     workspace_state: &OpenWorkspaceState,
 ) {
+    let pending_paths = active_pending_window_paths(config, ax_windows);
     let active_window = workspace_state
         .active_path
         .as_ref()
@@ -553,7 +650,11 @@ fn prepare_window_path_resolution(
                 .paths_by_name
                 .get(&project_name)
                 .is_some_and(|paths| paths.contains(active_path));
-            is_candidate.then(|| (*window_id, project_name, active_path.clone()))
+            let key = (config.id.to_string(), *window_id, project_name.clone());
+            let conflicts_with_pending =
+                pending_paths.get(&key).is_some_and(|path| path != active_path);
+            (is_candidate && !conflicts_with_pending)
+                .then(|| (*window_id, project_name, active_path.clone()))
         });
 
     let mut cache = match WINDOW_PATH_CACHE.lock() {
@@ -570,7 +671,12 @@ fn prepare_window_path_resolution(
                 .paths_by_name
                 .get(project_name)
                 .is_some_and(|paths| paths.contains(path));
-        window_exists && path_is_open
+        let path_is_pending = pending_paths.get(&(
+            editor_id.clone(),
+            *window_id,
+            project_name.clone(),
+        )) == Some(path);
+        window_exists && (path_is_open || path_is_pending)
     });
 
     let active_key = active_window.map(|(window_id, project_name, active_path)| {
@@ -584,20 +690,28 @@ fn prepare_window_path_resolution(
     let mut duplicate_keys = Vec::new();
     for (key, path) in cache.iter().filter(|(key, _)| key.0 == config.id) {
         let owner_key = (key.2.clone(), path.clone());
-        let is_active = active_key.as_ref() == Some(key);
-        if let Some((existing_key, existing_is_active)) = path_owners.get(&owner_key) {
-            if is_active && !existing_is_active {
+        let is_preferred =
+            active_key.as_ref() == Some(key) || pending_paths.get(key) == Some(path);
+        if let Some((existing_key, existing_is_preferred)) = path_owners.get(&owner_key) {
+            if is_preferred && !existing_is_preferred {
                 duplicate_keys.push(existing_key.clone());
                 path_owners.insert(owner_key, (key.clone(), true));
             } else {
                 duplicate_keys.push(key.clone());
             }
         } else {
-            path_owners.insert(owner_key, (key.clone(), is_active));
+            path_owners.insert(owner_key, (key.clone(), is_preferred));
         }
     }
     for key in duplicate_keys {
         cache.remove(&key);
+    }
+    drop(cache);
+
+    if let Some(active_key) = active_key {
+        if let Ok(mut pending_paths) = PENDING_WINDOW_PATHS.lock() {
+            pending_paths.remove(&active_key);
+        }
     }
 }
 
@@ -632,9 +746,13 @@ fn resolve_project_path(
         .get(project_name)
         .cloned()
         .unwrap_or_default();
+    let protected_path = pending_window_path(&window_cache_key);
     let mut cache = WINDOW_PATH_CACHE.lock().ok()?;
     if let Some(path) = cache.get(&window_cache_key) {
-        if !workspace_state.is_available || candidates.contains(path) {
+        if protected_path.as_ref() == Some(path)
+            || !workspace_state.is_available
+            || candidates.contains(path)
+        {
             return Some(path.clone());
         }
         cache.remove(&window_cache_key);
@@ -855,15 +973,13 @@ fn find_zed_cli() -> Option<PathBuf> {
     candidates.into_iter().find(|path| path.is_file())
 }
 
-fn current_editor_window_ids(config: &EditorConfig) -> HashSet<u32> {
+fn current_editor_window_ids(config: &EditorConfig) -> Result<HashSet<u32>, String> {
     let Some(pid) = ax_helper::get_pid_by_bundle_id(config.bundle_id) else {
-        return HashSet::new();
+        return Ok(HashSet::new());
     };
     ax_helper::get_native_windows_ax(pid, config.bundle_id, config.id == "cursor")
-        .unwrap_or_default()
-        .into_iter()
-        .map(|window| window.id)
-        .collect()
+        .map_err(|error| format!("Failed to inspect existing editor windows: {}", error))
+        .map(|windows| windows.into_iter().map(|window| window.id).collect())
 }
 
 fn project_path_matches_name(path: &Path, project_name: &str) -> bool {
@@ -879,6 +995,7 @@ fn match_pending_project_opens(
     config: &EditorConfig,
     pending_opens: &[PendingProjectOpen],
     native_windows: &[NativeEditorWindow],
+    resolved_window_ids: &HashSet<u32>,
 ) -> (HashMap<u32, PathBuf>, HashSet<usize>) {
     let windows = native_windows
         .iter()
@@ -896,10 +1013,14 @@ fn match_pending_project_opens(
 
     for index in pending_indices {
         let pending = &pending_opens[index];
+        if !pending.is_ready {
+            continue;
+        }
         let candidates = windows
             .iter()
             .filter(|(window_id, project_name)| {
                 !pending.existing_window_ids.contains(window_id)
+                    && !resolved_window_ids.contains(window_id)
                     && !assigned_window_ids.contains(window_id)
                     && project_path_matches_name(&pending.path, project_name)
             })
@@ -930,59 +1051,210 @@ fn match_pending_project_opens(
     (matches, consumed_pending_indices)
 }
 
-fn register_pending_project_open(
-    config: &EditorConfig,
-    path: &Path,
-    existing_window_ids: HashSet<u32>,
-) {
-    if let Ok(mut pending_by_editor) = PENDING_PROJECT_OPENS.lock() {
-        pending_by_editor
-            .entry(config.id.to_string())
-            .or_default()
-            .push(PendingProjectOpen {
-                path: path.to_path_buf(),
-                existing_window_ids,
-                created_at: Instant::now(),
+fn prune_expired_pending_project_opens(
+    pending_by_editor: &mut HashMap<String, Vec<PendingProjectOpen>>,
+    editor_id: &str,
+) -> bool {
+    let now = Instant::now();
+    let mut removed = false;
+    let is_empty = if let Some(pending_opens) = pending_by_editor.get_mut(editor_id) {
+        let previous_len = pending_opens.len();
+        pending_opens.retain(|pending| {
+            now.duration_since(pending.created_at) <= PENDING_PROJECT_OPEN_TTL
+        });
+        removed = pending_opens.len() != previous_len;
+        pending_opens.is_empty()
+    } else {
+        false
+    };
+    if is_empty {
+        pending_by_editor.remove(editor_id);
+    }
+    removed
+}
+
+fn reserve_pending_project_open(editor_id: &str, path: &Path) -> Result<u64, String> {
+    let mut pending_by_editor = PENDING_PROJECT_OPENS
+        .lock()
+        .map_err(|_| "Project open coordinator is unavailable".to_string())?;
+
+    loop {
+        if prune_expired_pending_project_opens(&mut pending_by_editor, editor_id) {
+            PENDING_PROJECT_OPEN_CHANGED.notify_all();
+        }
+        if !pending_by_editor.contains_key(editor_id) {
+            let request_id = NEXT_PENDING_PROJECT_OPEN_ID.fetch_add(1, Ordering::Relaxed);
+            pending_by_editor.insert(
+                editor_id.to_string(),
+                vec![PendingProjectOpen {
+                    request_id,
+                    path: path.to_path_buf(),
+                    existing_window_ids: HashSet::new(),
+                    created_at: Instant::now(),
+                    is_ready: false,
+                }],
+            );
+            return Ok(request_id);
+        }
+
+        let wait_duration = pending_by_editor
+            .get(editor_id)
+            .and_then(|pending_opens| {
+                pending_opens
+                    .iter()
+                    .map(|pending| {
+                        PENDING_PROJECT_OPEN_TTL
+                            .saturating_sub(pending.created_at.elapsed())
+                    })
+                    .min()
             });
+        pending_by_editor = if let Some(wait_duration) = wait_duration {
+            PENDING_PROJECT_OPEN_CHANGED
+                .wait_timeout(pending_by_editor, wait_duration)
+                .map_err(|_| "Project open coordinator is unavailable".to_string())?
+                .0
+        } else {
+            PENDING_PROJECT_OPEN_CHANGED
+                .wait(pending_by_editor)
+                .map_err(|_| "Project open coordinator is unavailable".to_string())?
+        };
+    }
+}
+
+fn mark_pending_project_open_ready(
+    editor_id: &str,
+    request_id: u64,
+    existing_window_ids: HashSet<u32>,
+) -> Result<(), String> {
+    let mut pending_by_editor = PENDING_PROJECT_OPENS
+        .lock()
+        .map_err(|_| "Project open coordinator is unavailable".to_string())?;
+    let pending = pending_by_editor
+        .get_mut(editor_id)
+        .and_then(|pending_opens| {
+            pending_opens
+                .iter_mut()
+                .find(|pending| pending.request_id == request_id)
+        })
+        .ok_or_else(|| "Project open request was cancelled".to_string())?;
+    pending.existing_window_ids = existing_window_ids;
+    pending.created_at = Instant::now();
+    pending.is_ready = true;
+    PENDING_PROJECT_OPEN_CHANGED.notify_all();
+    Ok(())
+}
+
+fn cancel_pending_project_open(editor_id: &str, request_id: u64) {
+    if let Ok(mut pending_by_editor) = PENDING_PROJECT_OPENS.lock() {
+        let is_empty = if let Some(pending_opens) = pending_by_editor.get_mut(editor_id) {
+            pending_opens.retain(|pending| pending.request_id != request_id);
+            pending_opens.is_empty()
+        } else {
+            false
+        };
+        if is_empty {
+            pending_by_editor.remove(editor_id);
+        }
+        PENDING_PROJECT_OPEN_CHANGED.notify_all();
+    }
+}
+
+fn snapshot_pending_project_opens(editor_id: &str) -> Vec<PendingProjectOpen> {
+    let mut pending_by_editor = match PENDING_PROJECT_OPENS.lock() {
+        Ok(pending) => pending,
+        Err(_) => return Vec::new(),
+    };
+    if prune_expired_pending_project_opens(&mut pending_by_editor, editor_id) {
+        PENDING_PROJECT_OPEN_CHANGED.notify_all();
+    }
+    pending_by_editor
+        .get(editor_id)
+        .map(|pending_opens| {
+            pending_opens
+                .iter()
+                .filter(|pending| pending.is_ready)
+                .cloned()
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn consume_pending_project_opens(editor_id: &str, request_ids: &HashSet<u64>) -> bool {
+    let mut pending_by_editor = match PENDING_PROJECT_OPENS.lock() {
+        Ok(pending) => pending,
+        Err(_) => return false,
+    };
+    let mut consumed = 0;
+    let is_empty = if let Some(pending_opens) = pending_by_editor.get_mut(editor_id) {
+        let previous_len = pending_opens.len();
+        pending_opens.retain(|pending| !request_ids.contains(&pending.request_id));
+        consumed = previous_len - pending_opens.len();
+        pending_opens.is_empty()
+    } else {
+        false
+    };
+    if is_empty {
+        pending_by_editor.remove(editor_id);
+    }
+    if consumed > 0 {
+        PENDING_PROJECT_OPEN_CHANGED.notify_all();
+    }
+    consumed == request_ids.len()
+}
+
+fn paths_refer_to_same_project(first: &Path, second: &Path) -> bool {
+    first == second
+        || std::fs::canonicalize(first)
+            .ok()
+            .zip(std::fs::canonicalize(second).ok())
+            .is_some_and(|(first, second)| first == second)
+}
+
+fn acknowledge_resolved_pending_project_open(
+    config: &EditorConfig,
+    resolved_paths: &HashMap<u32, PathBuf>,
+) {
+    let pending_opens = snapshot_pending_project_opens(config.id);
+    let request_ids = pending_opens
+        .iter()
+        .filter(|pending| {
+            resolved_paths
+                .values()
+                .any(|path| paths_refer_to_same_project(&pending.path, path))
+        })
+        .map(|pending| pending.request_id)
+        .collect::<HashSet<_>>();
+    if !request_ids.is_empty() {
+        consume_pending_project_opens(config.id, &request_ids);
     }
 }
 
 fn take_pending_project_open_paths(
     config: &EditorConfig,
     native_windows: &[NativeEditorWindow],
+    resolved_window_ids: &HashSet<u32>,
 ) -> HashMap<u32, PathBuf> {
-    let pending_opens = match PENDING_PROJECT_OPENS.lock() {
-        Ok(mut pending_by_editor) => pending_by_editor.remove(config.id).unwrap_or_default(),
-        Err(_) => return HashMap::new(),
-    };
-    let now = Instant::now();
-    let pending_opens = pending_opens
-        .into_iter()
-        .filter(|pending| now.duration_since(pending.created_at) <= PENDING_PROJECT_OPEN_TTL)
-        .collect::<Vec<_>>();
-    let (matches, consumed_indices) =
-        match_pending_project_opens(config, &pending_opens, native_windows);
-
-    let remaining = pending_opens
-        .into_iter()
-        .enumerate()
-        .filter_map(|(index, pending)| {
-            (!consumed_indices.contains(&index)).then_some(pending)
-        })
-        .collect::<Vec<_>>();
-    if !remaining.is_empty() {
-        if let Ok(mut pending_by_editor) = PENDING_PROJECT_OPENS.lock() {
-            pending_by_editor
-                .entry(config.id.to_string())
-                .or_default()
-                .extend(remaining);
-        }
+    let pending_opens = snapshot_pending_project_opens(config.id);
+    let (matches, consumed_indices) = match_pending_project_opens(
+        config,
+        &pending_opens,
+        native_windows,
+        resolved_window_ids,
+    );
+    let request_ids = consumed_indices
+        .iter()
+        .map(|index| pending_opens[*index].request_id)
+        .collect::<HashSet<_>>();
+    if request_ids.is_empty()
+        || !consume_pending_project_opens(config.id, &request_ids)
+    {
+        return HashMap::new();
     }
 
     for (window_id, path) in &matches {
         if let Some(window) = native_windows.iter().find(|window| window.id == *window_id) {
             let project_name = extract_project_name(&window.title, config);
-            cache_window_path(config.id, *window_id, &project_name, path);
+            cache_pending_window_path(config.id, *window_id, &project_name, path);
         }
     }
     matches
@@ -1015,15 +1287,36 @@ pub fn open_project_in_editor(bundle_id: &str, path: &str) -> Result<(), String>
         return Err(format!("Project path does not exist: {}", path));
     }
 
-    let existing_window_ids = current_editor_window_ids(config);
+    let request_id = reserve_pending_project_open(config.id, Path::new(path))?;
+    let existing_window_ids = current_editor_window_ids(config).ok();
     let zed_cli = (config.id == "zed").then(find_zed_cli).flatten();
-    let status = build_project_open_command(config, path, zed_cli.as_deref())?
-        .status()
-        .map_err(|e| format!("Failed to open project: {}", e))?;
+    let status = match build_project_open_command(config, path, zed_cli.as_deref())
+        .and_then(|mut command| {
+            command
+                .status()
+                .map_err(|e| format!("Failed to open project: {}", e))
+        }) {
+        Ok(status) => status,
+        Err(error) => {
+            cancel_pending_project_open(config.id, request_id);
+            return Err(error);
+        }
+    };
     if status.success() {
-        register_pending_project_open(config, Path::new(path), existing_window_ids);
+        if let Some(existing_window_ids) = existing_window_ids {
+            if let Err(error) =
+                mark_pending_project_open_ready(config.id, request_id, existing_window_ids)
+            {
+                cancel_pending_project_open(config.id, request_id);
+                return Err(error);
+            }
+        } else {
+            cancel_pending_project_open(config.id, request_id);
+        }
+        crate::window_registry::request_refresh("project-open");
         Ok(())
     } else {
+        cancel_pending_project_open(config.id, request_id);
         Err(format!("Failed to open project in {}", config.display_name))
     }
 }
@@ -1051,9 +1344,11 @@ mod tests {
 
     fn pending_open(path: &str, existing_window_ids: &[u32]) -> PendingProjectOpen {
         PendingProjectOpen {
+            request_id: 0,
             path: PathBuf::from(path),
             existing_window_ids: existing_window_ids.iter().copied().collect(),
             created_at: Instant::now(),
+            is_ready: true,
         }
     }
 
@@ -1110,8 +1405,12 @@ mod tests {
             let pending = vec![pending_open("/projects/api", &[100])];
             let windows = vec![native_window(100, title), native_window(200, title)];
 
-            let (matches, consumed) =
-                match_pending_project_opens(config, &pending, &windows);
+            let (matches, consumed) = match_pending_project_opens(
+                config,
+                &pending,
+                &windows,
+                &HashSet::new(),
+            );
 
             assert_eq!(matches[&200], PathBuf::from("/projects/api"));
             assert_eq!(consumed, HashSet::from([0]));
@@ -1132,8 +1431,12 @@ mod tests {
             native_window(300, "project"),
         ];
 
-        let (matches, consumed) =
-            match_pending_project_opens(config, &pending, &windows);
+        let (matches, consumed) = match_pending_project_opens(
+            config,
+            &pending,
+            &windows,
+            &HashSet::new(),
+        );
 
         assert_eq!(matches[&200], PathBuf::from("/worktrees/one/project"));
         assert_eq!(matches[&300], PathBuf::from("/worktrees/two/project"));
@@ -1153,11 +1456,160 @@ mod tests {
             native_window(200, "project"),
         ];
 
-        let (matches, consumed) =
-            match_pending_project_opens(config, &pending, &windows);
+        let (matches, consumed) = match_pending_project_opens(
+            config,
+            &pending,
+            &windows,
+            &HashSet::new(),
+        );
 
         assert!(matches.is_empty());
         assert!(consumed.is_empty());
+    }
+
+    #[test]
+    fn pending_open_does_not_consume_an_already_resolved_window() {
+        let config =
+            crate::editor_config::get_editor_by_bundle_id("com.microsoft.VSCode").unwrap();
+        let pending = vec![pending_open("/projects/api", &[100])];
+        let windows = vec![
+            native_window(100, "api — Visual Studio Code"),
+            native_window(200, "api — Visual Studio Code"),
+        ];
+
+        let (matches, consumed) = match_pending_project_opens(
+            config,
+            &pending,
+            &windows,
+            &HashSet::from([200]),
+        );
+
+        assert!(matches.is_empty());
+        assert!(consumed.is_empty());
+    }
+
+    #[test]
+    fn resolved_existing_target_acknowledges_pending_open() {
+        let config = EditorConfig {
+            id: "pending-acknowledgement-test",
+            display_name: "Sample Editor",
+            bundle_id: "com.example.pending-acknowledgement",
+            app_name: "Sample Editor",
+        };
+        let path = PathBuf::from("/projects/api");
+        let request_id = reserve_pending_project_open(config.id, &path).unwrap();
+        mark_pending_project_open_ready(
+            config.id,
+            request_id,
+            HashSet::from([100]),
+        )
+        .unwrap();
+
+        acknowledge_resolved_pending_project_open(
+            &config,
+            &HashMap::from([(100, path.clone())]),
+        );
+        assert!(snapshot_pending_project_opens(config.id).is_empty());
+    }
+
+    #[test]
+    fn project_open_reservations_are_serialized_per_editor() {
+        let config = EditorConfig {
+            id: "pending-serialization-test",
+            display_name: "Sample Editor",
+            bundle_id: "com.example.pending-serialization",
+            app_name: "Sample Editor",
+        };
+        let first = reserve_pending_project_open(
+            config.id,
+            Path::new("/worktrees/one/project"),
+        )
+        .unwrap();
+        mark_pending_project_open_ready(config.id, first, HashSet::from([100])).unwrap();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let waiter = std::thread::spawn(move || {
+            let second = reserve_pending_project_open(
+                "pending-serialization-test",
+                Path::new("/worktrees/two/project"),
+            )
+            .unwrap();
+            tx.send(second).unwrap();
+        });
+
+        assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
+
+        let matches = take_pending_project_open_paths(
+            &config,
+            &[native_window(100, "project"), native_window(200, "project")],
+            &HashSet::new(),
+        );
+        assert_eq!(
+            matches.get(&200),
+            Some(&PathBuf::from("/worktrees/one/project"))
+        );
+        let second = rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        cancel_pending_project_open(config.id, second);
+        waiter.join().unwrap();
+        invalidate_path_cache_for_editor(config.id);
+    }
+
+    #[test]
+    fn launching_reservation_expires_instead_of_blocking_forever() {
+        let editor_id = "pending-launch-timeout-test";
+        {
+            let mut pending_by_editor = PENDING_PROJECT_OPENS.lock().unwrap();
+            pending_by_editor.insert(
+                editor_id.to_string(),
+                vec![PendingProjectOpen {
+                    request_id: 999,
+                    path: PathBuf::from("/worktrees/old/project"),
+                    existing_window_ids: HashSet::new(),
+                    created_at: Instant::now()
+                        .checked_sub(PENDING_PROJECT_OPEN_TTL + Duration::from_secs(1))
+                        .unwrap(),
+                    is_ready: false,
+                }],
+            );
+        }
+
+        let request_id =
+            reserve_pending_project_open(editor_id, Path::new("/worktrees/new/project")).unwrap();
+
+        assert_ne!(request_id, 999);
+        cancel_pending_project_open(editor_id, request_id);
+    }
+
+    #[test]
+    fn pending_window_path_survives_stale_workspace_state() {
+        let config = EditorConfig {
+            id: "pending-cache-test",
+            display_name: "Sample Editor",
+            bundle_id: "com.example.pending-cache",
+            app_name: "Sample Editor",
+        };
+        let path = PathBuf::from("/worktrees/one/project");
+        let stale_active_path = PathBuf::from("/worktrees/old/project");
+        cache_pending_window_path(config.id, 200, "project", &path);
+        let windows = vec![(200, "project — Sample Editor".to_string(), true)];
+        let workspace_state = OpenWorkspaceState {
+            is_available: true,
+            active_path: Some(stale_active_path.clone()),
+            all_paths: vec![stale_active_path.clone()],
+            paths_by_name: HashMap::from([(
+                "project".to_string(),
+                vec![stale_active_path],
+            )]),
+        };
+
+        prepare_window_path_resolution(&config, &windows, &workspace_state);
+
+        let cache = WINDOW_PATH_CACHE.lock().unwrap();
+        assert_eq!(
+            cache.get(&(config.id.to_string(), 200, "project".to_string())),
+            Some(&path)
+        );
+        drop(cache);
+        invalidate_path_cache_for_editor(config.id);
     }
 
     fn editor_session(id: u32, title: &str, path: Option<&str>) -> EditorSession {

--- a/src-tauri/src/editor.rs
+++ b/src-tauri/src/editor.rs
@@ -5,7 +5,9 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
-pub use crate::editor_model::{EditorState, EditorWindow, WorkspaceResolution};
+pub use crate::editor_model::{
+    EditorState, EditorWindow, ProjectMetadata, WorkspaceResolution,
+};
 
 type WindowPathCacheKey = (String, u32, String);
 type WorkspacePathOwnerKey = (String, PathBuf);
@@ -787,6 +789,25 @@ fn get_git_branch(git_root: &std::path::Path) -> Option<String> {
     }
 }
 
+pub fn get_project_metadata(paths: Vec<String>) -> Vec<ProjectMetadata> {
+    let mut seen_paths = HashSet::new();
+    paths
+        .into_iter()
+        .filter(|path| seen_paths.insert(path.clone()))
+        .map(|path| {
+            let git_root = find_git_root(Path::new(&path));
+            let branch = git_root.as_ref().and_then(|root| get_git_branch(root));
+            let repository = git_root.as_ref().and_then(|root| get_repository_info(root));
+            ProjectMetadata {
+                path,
+                branch,
+                repository_id: repository.as_ref().map(|(id, _)| id.clone()),
+                repository_name: repository.map(|(_, name)| name),
+            }
+        })
+        .collect()
+}
+
 /// Focus a specific editor window by CGWindowID
 /// Uses CGWindowID for reliable window identification regardless of title changes
 pub fn focus_editor_window(bundle_id: &str, window_id: u32) -> Result<(), String> {
@@ -1346,6 +1367,46 @@ mod tests {
 
         assert_eq!(main_info, worktree_info);
         assert_eq!(main_info.1, "project");
+    }
+
+    #[test]
+    fn project_metadata_restores_linked_worktree_git_information() {
+        let tmp = tempfile::tempdir().unwrap();
+        let main = tmp.path().join("project");
+        let main_git = main.join(".git");
+        let worktree_git = main_git.join("worktrees/feature");
+        fs::create_dir_all(&worktree_git).unwrap();
+
+        let worktree = tmp.path().join("project-feature");
+        fs::create_dir(&worktree).unwrap();
+        fs::write(
+            worktree.join(".git"),
+            format!("gitdir: {}\n", worktree_git.display()),
+        )
+        .unwrap();
+        fs::write(worktree_git.join("commondir"), "../..\n").unwrap();
+        fs::write(
+            worktree_git.join("HEAD"),
+            "ref: refs/heads/feature/saved-tab\n",
+        )
+        .unwrap();
+
+        let metadata =
+            get_project_metadata(vec![worktree.to_string_lossy().to_string()]);
+
+        assert_eq!(metadata.len(), 1);
+        assert_eq!(
+            metadata[0].branch,
+            Some("feature/saved-tab".to_string())
+        );
+        assert_eq!(
+            metadata[0].repository_id,
+            Some(std::fs::canonicalize(main_git).unwrap().to_string_lossy().to_string())
+        );
+        assert_eq!(
+            metadata[0].repository_name,
+            Some("project".to_string())
+        );
     }
 
     #[test]

--- a/src-tauri/src/editor_model.rs
+++ b/src-tauri/src/editor_model.rs
@@ -59,6 +59,14 @@ pub struct EditorWindow {
     pub resolution: WorkspaceResolution,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct ProjectMetadata {
+    pub path: String,
+    pub branch: Option<String>,
+    pub repository_id: Option<String>,
+    pub repository_name: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EditorState {
     pub is_active: bool,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -50,8 +50,12 @@ fn close_editor_window(bundle_id: &str, window_id: u32) -> Result<(), String> {
 }
 
 #[tauri::command(rename_all = "snake_case")]
-fn open_project_in_editor(bundle_id: &str, path: &str) -> Result<(), String> {
-    editor::open_project_in_editor(bundle_id, path)
+async fn open_project_in_editor(bundle_id: String, path: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        editor::open_project_in_editor(&bundle_id, &path)
+    })
+    .await
+    .map_err(|error| format!("Failed to join project open task: {}", error))?
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,6 +54,11 @@ fn open_project_in_editor(bundle_id: &str, path: &str) -> Result<(), String> {
     editor::open_project_in_editor(bundle_id, path)
 }
 
+#[tauri::command]
+fn get_project_metadata(paths: Vec<String>) -> Vec<editor::ProjectMetadata> {
+    editor::get_project_metadata(paths)
+}
+
 #[tauri::command(rename_all = "snake_case")]
 fn maximize_editor_window(bundle_id: &str, window_id: u32, tab_bar_height: f64) -> Result<(), String> {
     window_offset::maximize_window(bundle_id, window_id, tab_bar_height)
@@ -265,6 +270,7 @@ pub fn run() {
             open_new_editor,
             close_editor_window,
             open_project_in_editor,
+            get_project_metadata,
             maximize_editor_window,
             is_editor_active,
             // File operations

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,9 +45,7 @@ function App() {
   });
 
   // 2. History (reads bridge ref lazily)
-  const history = useHistory({
-    refreshWindowsRef: refreshWindowsBridgeRef,
-  });
+  const history = useHistory();
 
   // 3. Editor windows
   const editorWindows = useEditorWindows({
@@ -122,7 +120,12 @@ function App() {
       showAddMenu={history.showAddMenu}
       onAddMenuOpen={lifecycle.handleAddMenuOpen}
       onAddMenuClose={lifecycle.handleAddMenuClose}
-      onHistorySelect={history.handleOpenFromHistory}
+      onEditorPickerOpen={lifecycle.handleEditorPickerOpen}
+      onEditorPickerClose={lifecycle.handleEditorPickerClose}
+      onHistorySelect={(entry, bundleId) =>
+        editorWindows.handleOpenProject(entry.path, bundleId)
+      }
+      onClosedTabOpen={editorWindows.handleOpenSavedTab}
       onHistoryClear={history.handleClearHistory}
       groups={editorWindows.groups}
       groupAssignments={editorWindows.groupAssignments}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -120,6 +120,7 @@ function App() {
       showAddMenu={history.showAddMenu}
       onAddMenuOpen={lifecycle.handleAddMenuOpen}
       onAddMenuClose={lifecycle.handleAddMenuClose}
+      onAddMenuHandoff={lifecycle.handleAddMenuHandoff}
       onEditorPickerOpen={lifecycle.handleEditorPickerOpen}
       onEditorPickerClose={lifecycle.handleEditorPickerClose}
       onHistorySelect={(entry, bundleId) =>

--- a/src/components/AddTabMenu.test.tsx
+++ b/src/components/AddTabMenu.test.tsx
@@ -35,8 +35,8 @@ describe("AddTabMenu", () => {
     fireEvent.click(screen.getByRole("button", { name: /^sample-project/ }));
 
     await vi.waitFor(() => {
-      expect(onClose).toHaveBeenCalledOnce();
       expect(onSelectHistory).toHaveBeenCalledWith(historyEntry, expect.anything());
+      expect(onClose).not.toHaveBeenCalled();
     });
   });
 
@@ -46,8 +46,18 @@ describe("AddTabMenu", () => {
     fireEvent.click(screen.getByRole("button", { name: /history\.newWindow/ }));
 
     await vi.waitFor(() => {
-      expect(onClose).toHaveBeenCalledOnce();
       expect(onNewWindow).toHaveBeenCalledWith(expect.anything());
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  it("closes normally when pressing Escape", async () => {
+    const { onClose } = renderMenu();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await vi.waitFor(() => {
+      expect(onClose).toHaveBeenCalledOnce();
     });
   });
 

--- a/src/components/AddTabMenu.test.tsx
+++ b/src/components/AddTabMenu.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { HistoryEntry } from "../types/editor";
+import AddTabMenu from "./AddTabMenu";
+
+const historyEntry: HistoryEntry = {
+  name: "sample-project",
+  path: "/Users/test/sample-project",
+  timestamp: Date.now(),
+};
+
+function renderMenu(entries: HistoryEntry[] = [historyEntry]) {
+  const onNewWindow = vi.fn().mockResolvedValue(undefined);
+  const onSelectHistory = vi.fn().mockResolvedValue(undefined);
+  const onClose = vi.fn().mockResolvedValue(undefined);
+  const anchor = document.createElement("button");
+
+  render(
+    <AddTabMenu
+      entries={entries}
+      onNewWindow={onNewWindow}
+      onSelectHistory={onSelectHistory}
+      onClearHistory={vi.fn()}
+      onClose={onClose}
+      anchorRef={{ current: anchor }}
+    />,
+  );
+
+  return { onNewWindow, onSelectHistory, onClose };
+}
+
+describe("AddTabMenu", () => {
+  it("requests an editor after selecting a recent project", async () => {
+    const { onSelectHistory, onClose } = renderMenu();
+
+    fireEvent.click(screen.getByRole("button", { name: /^sample-project/ }));
+
+    await vi.waitFor(() => {
+      expect(onClose).toHaveBeenCalledOnce();
+      expect(onSelectHistory).toHaveBeenCalledWith(historyEntry, expect.anything());
+    });
+  });
+
+  it("requests an editor after selecting a new window", async () => {
+    const { onNewWindow, onClose } = renderMenu();
+
+    fireEvent.click(screen.getByRole("button", { name: /history\.newWindow/ }));
+
+    await vi.waitFor(() => {
+      expect(onClose).toHaveBeenCalledOnce();
+      expect(onNewWindow).toHaveBeenCalledWith(expect.anything());
+    });
+  });
+
+  it("shows project history without editor-specific filtering", () => {
+    renderMenu([
+      historyEntry,
+      {
+        name: "another-project",
+        path: "/Users/test/another-project",
+        timestamp: Date.now() - 1000,
+      },
+    ]);
+
+    expect(screen.getByRole("button", { name: /^sample-project/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^another-project/ })).toBeInTheDocument();
+  });
+});

--- a/src/components/AddTabMenu.tsx
+++ b/src/components/AddTabMenu.tsx
@@ -75,7 +75,6 @@ function AddTabMenu({
           style={styles.newWindowButton}
           onClick={async (event) => {
             const anchorRect = event.currentTarget.getBoundingClientRect();
-            await onClose();
             await onNewWindow(anchorRect);
           }}
           onMouseEnter={(event) => {
@@ -101,7 +100,6 @@ function AddTabMenu({
                   style={styles.historyItem}
                   onClick={async (event) => {
                     const anchorRect = event.currentTarget.getBoundingClientRect();
-                    await onClose();
                     await onSelectHistory(entry, anchorRect);
                   }}
                   onMouseEnter={(event) => {

--- a/src/components/AddTabMenu.tsx
+++ b/src/components/AddTabMenu.tsx
@@ -1,19 +1,21 @@
 import { useEffect, useRef, useState, type RefObject } from "react";
 import { useTranslation } from "react-i18next";
-import type { EditorWindow, HistoryEntry } from "../types/editor";
-import { normalizeProjectPath, windowKey } from "../utils/store";
+import type { HistoryEntry } from "../types/editor";
+import { normalizeProjectPath } from "../utils/store";
 
 interface AddTabMenuProps {
   entries: HistoryEntry[];
-  currentWindows: EditorWindow[];
-  onNewWindow: () => void;
-  onSelectHistory: (entry: HistoryEntry) => void;
+  onNewWindow: (anchorRect: DOMRect) => Promise<void>;
+  onSelectHistory: (entry: HistoryEntry, anchorRect: DOMRect) => Promise<void>;
   onClearHistory: () => void;
-  onClose: () => void;
+  onClose: () => Promise<void>;
   anchorRef: RefObject<HTMLButtonElement | null>;
 }
 
-function formatRelativeTime(timestamp: number, t: (key: string, options?: Record<string, unknown>) => string): string {
+function formatRelativeTime(
+  timestamp: number,
+  t: (key: string, options?: Record<string, unknown>) => string,
+): string {
   const diff = Date.now() - timestamp;
   const minutes = Math.floor(diff / 60000);
   const hours = Math.floor(diff / 3600000);
@@ -25,49 +27,34 @@ function formatRelativeTime(timestamp: number, t: (key: string, options?: Record
   return t("history.daysAgo", { count: days });
 }
 
-function AddTabMenu({ entries, currentWindows, onNewWindow, onSelectHistory, onClearHistory, onClose, anchorRef }: AddTabMenuProps) {
+function AddTabMenu({
+  entries,
+  onNewWindow,
+  onSelectHistory,
+  onClearHistory,
+  onClose,
+  anchorRef,
+}: AddTabMenuProps) {
   const { t } = useTranslation();
   const [menuPos, setMenuPos] = useState<{ top: number; left: number } | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
-  // Filter out currently open tabs from history
-  const currentWindowKeys = new Set(currentWindows.map(windowKey));
-  const filteredEntries = entries.filter(
-    (entry) => !currentWindowKeys.has(`${entry.bundleId}:${normalizeProjectPath(entry.path)}`)
-  );
-
-  // Calculate position from anchor button
   useEffect(() => {
-    if (anchorRef.current) {
-      const rect = anchorRef.current.getBoundingClientRect();
-      const MENU_WIDTH = 280;
-      const VIEWPORT_PADDING = 4;
+    if (!anchorRef.current) return;
 
-      // デフォルト: ボタンの右端にメニューの右端を揃える
-      let left = rect.right - MENU_WIDTH;
-
-      // 左端がviewport外に出ないようクランプ
-      if (left < VIEWPORT_PADDING) {
-        left = VIEWPORT_PADDING;
-      }
-
-      // 右端がviewport外に出ないようクランプ
-      if (left + MENU_WIDTH > window.innerWidth - VIEWPORT_PADDING) {
-        left = window.innerWidth - MENU_WIDTH - VIEWPORT_PADDING;
-      }
-
-      setMenuPos({
-        top: rect.bottom + 4,
-        left,
-      });
-    }
+    const rect = anchorRef.current.getBoundingClientRect();
+    const menuWidth = 280;
+    const viewportPadding = 4;
+    const left = Math.min(
+      Math.max(viewportPadding, rect.right - menuWidth),
+      window.innerWidth - menuWidth - viewportPadding,
+    );
+    setMenuPos({ top: rect.bottom + 4, left });
   }, [anchorRef]);
 
   useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        onClose();
-      }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") void onClose();
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
@@ -75,7 +62,7 @@ function AddTabMenu({ entries, currentWindows, onNewWindow, onSelectHistory, onC
 
   return (
     <>
-      <div style={styles.overlay} onClick={onClose} />
+      <div style={styles.overlay} onClick={() => void onClose()} />
       <div
         ref={menuRef}
         style={{
@@ -83,75 +70,71 @@ function AddTabMenu({ entries, currentWindows, onNewWindow, onSelectHistory, onC
           ...(menuPos ? { top: menuPos.top, left: menuPos.left } : { top: 40, left: 8 }),
         }}
       >
-        {/* New Window */}
         <button
+          type="button"
           style={styles.newWindowButton}
-          onClick={() => {
-            onNewWindow();
-            onClose();
+          onClick={async (event) => {
+            const anchorRect = event.currentTarget.getBoundingClientRect();
+            await onClose();
+            await onNewWindow(anchorRect);
           }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.background = "#3a3a3a";
+          onMouseEnter={(event) => {
+            event.currentTarget.style.background = "#3a3a3a";
           }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.background = "transparent";
+          onMouseLeave={(event) => {
+            event.currentTarget.style.background = "transparent";
           }}
         >
           <span style={styles.newWindowIcon}>+</span>
           <span>{t("history.newWindow")}</span>
         </button>
 
-        {/* History section */}
-        {filteredEntries.length > 0 && (
+        {entries.length > 0 ? (
           <>
             <div style={styles.separator} />
             <div style={styles.sectionHeader}>{t("history.recentProjects")}</div>
             <div style={styles.historyList}>
-              {filteredEntries.map((entry) => (
+              {entries.map((entry) => (
                 <button
-                  key={`${entry.bundleId}:${entry.path}`}
+                  key={normalizeProjectPath(entry.path)}
+                  type="button"
                   style={styles.historyItem}
-                  onClick={() => {
-                    onSelectHistory(entry);
-                    onClose();
+                  onClick={async (event) => {
+                    const anchorRect = event.currentTarget.getBoundingClientRect();
+                    await onClose();
+                    await onSelectHistory(entry, anchorRect);
                   }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.background = "#3a3a3a";
+                  onMouseEnter={(event) => {
+                    event.currentTarget.style.background = "#3a3a3a";
                   }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.background = "transparent";
+                  onMouseLeave={(event) => {
+                    event.currentTarget.style.background = "transparent";
                   }}
                 >
-                  <div style={styles.historyItemContent}>
-                    <div style={styles.historyItemTop}>
-                      <span style={styles.historyName}>{entry.name}</span>
-                      <span style={styles.historyEditor}>{entry.editorName}</span>
-                    </div>
-                    <span style={styles.historyTime}>{formatRelativeTime(entry.timestamp, t)}</span>
-                  </div>
+                  <span style={styles.historyName}>{entry.name}</span>
+                  <span style={styles.historyTime}>{formatRelativeTime(entry.timestamp, t)}</span>
                 </button>
               ))}
             </div>
             <div style={styles.separator} />
             <button
+              type="button"
               style={styles.clearButton}
               onClick={() => {
                 onClearHistory();
                 onClose();
               }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.background = "#3a3a3a";
+              onMouseEnter={(event) => {
+                event.currentTarget.style.background = "#3a3a3a";
               }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.background = "transparent";
+              onMouseLeave={(event) => {
+                event.currentTarget.style.background = "transparent";
               }}
             >
               {t("history.clear")}
             </button>
           </>
-        )}
-
-        {filteredEntries.length === 0 && (
+        ) : (
           <>
             <div style={styles.separator} />
             <div style={styles.emptyText}>{t("history.empty")}</div>
@@ -165,10 +148,7 @@ function AddTabMenu({ entries, currentWindows, onNewWindow, onSelectHistory, onC
 const styles: Record<string, React.CSSProperties> = {
   overlay: {
     position: "fixed",
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
+    inset: 0,
     zIndex: 100,
   },
   container: {
@@ -198,70 +178,49 @@ const styles: Record<string, React.CSSProperties> = {
     textAlign: "left",
   },
   newWindowIcon: {
-    fontSize: "16px",
-    color: "rgba(255, 255, 255, 0.7)",
     width: "20px",
-    textAlign: "center" as const,
+    color: "rgba(255, 255, 255, 0.7)",
+    fontSize: "16px",
+    textAlign: "center",
   },
   separator: {
     height: "1px",
+    margin: 0,
     background: "#404040",
-    margin: "0",
   },
   sectionHeader: {
     padding: "6px 12px 4px",
-    fontSize: "11px",
     color: "rgba(255, 255, 255, 0.4)",
-    textTransform: "uppercase" as const,
-    letterSpacing: "0.5px",
+    fontSize: "11px",
+    textTransform: "uppercase",
   },
   historyList: {
-    overflowY: "auto" as const,
     maxHeight: "300px",
+    overflowY: "auto",
   },
   historyItem: {
     display: "flex",
-    alignItems: "center",
+    flexDirection: "column",
+    gap: "2px",
     width: "100%",
     padding: "6px 12px",
     border: "none",
     background: "transparent",
     color: "#e0e0e0",
-    fontSize: "13px",
     cursor: "pointer",
     textAlign: "left",
   },
-  historyItemContent: {
-    display: "flex",
-    flexDirection: "column" as const,
-    gap: "2px",
-    width: "100%",
-    overflow: "hidden",
-  },
-  historyItemTop: {
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "space-between",
-    gap: "8px",
-  },
   historyName: {
     overflow: "hidden",
+    fontSize: "13px",
     textOverflow: "ellipsis",
-    whiteSpace: "nowrap" as const,
-    flex: 1,
-  },
-  historyEditor: {
-    fontSize: "11px",
-    color: "rgba(255, 255, 255, 0.4)",
-    flexShrink: 0,
+    whiteSpace: "nowrap",
   },
   historyTime: {
-    fontSize: "11px",
     color: "rgba(255, 255, 255, 0.35)",
+    fontSize: "11px",
   },
   clearButton: {
-    display: "flex",
-    alignItems: "center",
     width: "100%",
     padding: "8px 12px",
     border: "none",
@@ -273,9 +232,9 @@ const styles: Record<string, React.CSSProperties> = {
   },
   emptyText: {
     padding: "12px",
-    fontSize: "12px",
     color: "rgba(255, 255, 255, 0.35)",
-    textAlign: "center" as const,
+    fontSize: "12px",
+    textAlign: "center",
   },
 };
 

--- a/src/components/EditorPicker.test.tsx
+++ b/src/components/EditorPicker.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import EditorPicker from "./EditorPicker";
+
+const anchorRect = {
+  left: 8,
+  right: 108,
+  top: 0,
+  bottom: 32,
+  width: 100,
+  height: 32,
+  x: 8,
+  y: 0,
+  toJSON: () => ({}),
+} as DOMRect;
+
+describe("EditorPicker", () => {
+  it("opens the target with the selected editor", async () => {
+    const onSelect = vi.fn().mockResolvedValue(true);
+    const onClose = vi.fn();
+    render(
+      <EditorPicker
+        targetName="sample-project"
+        anchorRect={anchorRect}
+        onSelect={onSelect}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Cursor" }));
+
+    expect(onSelect).toHaveBeenCalledWith("com.todesktop.230313mzl4w4u92");
+    await vi.waitFor(() => expect(onClose).toHaveBeenCalledOnce());
+  });
+
+  it("keeps the picker open and shows an error when opening fails", async () => {
+    render(
+      <EditorPicker
+        targetName="sample-project"
+        anchorRect={anchorRect}
+        onSelect={vi.fn().mockResolvedValue(false)}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Zed" }));
+
+    expect(await screen.findByRole("status")).toHaveTextContent("history.openFailed");
+    expect(screen.getByRole("dialog", { name: "history.chooseEditor" })).toBeInTheDocument();
+  });
+});

--- a/src/components/EditorPicker.tsx
+++ b/src/components/EditorPicker.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { EDITOR_DISPLAY_NAMES, PROJECT_EDITOR_BUNDLE_IDS } from "../types/editor";
+import type { ProjectEditorBundleId } from "../types/editor";
+
+interface EditorPickerProps {
+  targetName: string;
+  anchorRect: DOMRect;
+  onSelect: (bundleId: ProjectEditorBundleId) => Promise<boolean>;
+  onClose: () => void;
+}
+
+const PICKER_WIDTH = 220;
+const PICKER_HEIGHT = 130;
+const VIEWPORT_PADDING = 4;
+
+function EditorPicker({ targetName, anchorRect, onSelect, onClose }: EditorPickerProps) {
+  const { t } = useTranslation();
+  const [opening, setOpening] = useState(false);
+  const [errorEditor, setErrorEditor] = useState<string | null>(null);
+  const left = Math.min(
+    Math.max(VIEWPORT_PADDING, anchorRect.left),
+    window.innerWidth - PICKER_WIDTH - VIEWPORT_PADDING,
+  );
+  const top = anchorRect.bottom + VIEWPORT_PADDING + PICKER_HEIGHT <= window.innerHeight
+    ? anchorRect.bottom + VIEWPORT_PADDING
+    : Math.max(VIEWPORT_PADDING, anchorRect.top - PICKER_HEIGHT - VIEWPORT_PADDING);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  const handleSelect = async (bundleId: ProjectEditorBundleId) => {
+    setOpening(true);
+    setErrorEditor(null);
+    const opened = await onSelect(bundleId);
+    if (opened) {
+      onClose();
+      return;
+    }
+    setOpening(false);
+    setErrorEditor(EDITOR_DISPLAY_NAMES[bundleId]);
+  };
+
+  return (
+    <>
+      <div style={styles.overlay} onClick={onClose} />
+      <div
+        role="dialog"
+        aria-label={t("history.chooseEditor")}
+        style={{
+          ...styles.container,
+          top,
+          left,
+        }}
+      >
+        <div style={styles.header}>
+          <span style={styles.title}>{t("history.chooseEditor")}</span>
+          <span style={styles.targetName}>{targetName}</span>
+        </div>
+        <div style={styles.editorList}>
+          {PROJECT_EDITOR_BUNDLE_IDS.map((bundleId) => (
+            <button
+              key={bundleId}
+              type="button"
+              disabled={opening}
+              style={styles.editorButton}
+              onClick={() => void handleSelect(bundleId)}
+            >
+              {EDITOR_DISPLAY_NAMES[bundleId]}
+            </button>
+          ))}
+        </div>
+        {errorEditor && (
+          <div role="status" style={styles.errorText}>
+            {t("history.openFailed", { editor: errorEditor })}
+          </div>
+        )}
+        <button type="button" disabled={opening} style={styles.cancelButton} onClick={onClose}>
+          {t("history.cancel")}
+        </button>
+      </div>
+    </>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  overlay: {
+    position: "fixed",
+    inset: 0,
+    zIndex: 102,
+  },
+  container: {
+    position: "fixed",
+    width: `${PICKER_WIDTH}px`,
+    overflow: "hidden",
+    border: "1px solid #404040",
+    borderRadius: "8px",
+    background: "#2d2d2d",
+    boxShadow: "0 4px 16px rgba(0, 0, 0, 0.5)",
+    zIndex: 103,
+  },
+  header: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "2px",
+    padding: "8px 10px 6px",
+  },
+  title: {
+    color: "rgba(255, 255, 255, 0.55)",
+    fontSize: "11px",
+  },
+  targetName: {
+    overflow: "hidden",
+    color: "#e0e0e0",
+    fontSize: "12px",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  editorList: {
+    display: "flex",
+    gap: "6px",
+    padding: "2px 10px 8px",
+  },
+  editorButton: {
+    flex: 1,
+    padding: "5px 4px",
+    border: "1px solid #505050",
+    borderRadius: "5px",
+    background: "#383838",
+    color: "#e0e0e0",
+    fontSize: "11px",
+    cursor: "pointer",
+  },
+  errorText: {
+    padding: "6px 10px",
+    borderTop: "1px solid #404040",
+    color: "#f0a0a0",
+    fontSize: "11px",
+  },
+  cancelButton: {
+    width: "100%",
+    padding: "7px 10px",
+    border: "none",
+    borderTop: "1px solid #404040",
+    background: "transparent",
+    color: "rgba(255, 255, 255, 0.55)",
+    fontSize: "11px",
+    cursor: "pointer",
+  },
+};
+
+export default EditorPicker;

--- a/src/components/GroupTabList.tsx
+++ b/src/components/GroupTabList.tsx
@@ -15,9 +15,9 @@ interface GroupTabListProps {
   showBranch: boolean;
   anchorLeft: number;
   expandedRepositories: ReadonlySet<string>;
-  onTabClick: (index: number) => void;
+  onTabClick: (index: number, anchorRect: DOMRect) => void;
   onCloseTab: (index: number) => void;
-  onRequestClose: () => void;
+  onRequestClose: () => Promise<void>;
   onTabContextMenu: (index: number, rect: DOMRect) => void;
   onRepositoryContextMenu: (
     repositoryId: string,
@@ -84,7 +84,7 @@ function GroupTabList({
   useEffect(() => {
     const handlePointerDown = (event: MouseEvent) => {
       if (menuRef.current?.contains(event.target as Node)) return;
-      onRequestClose();
+      void onRequestClose();
     };
     document.addEventListener("mousedown", handlePointerDown, true);
     return () => document.removeEventListener("mousedown", handlePointerDown, true);
@@ -95,7 +95,7 @@ function GroupTabList({
   }, [onRowCountChange, visibleRowCount]);
 
   const renderTabRow = ({ tab, originalIndex }: TabEntry, nested = false) => {
-    const isActive = originalIndex === activeIndex;
+    const isActive = tab.is_open !== false && originalIndex === activeIndex;
     const status = statuses.get(originalIndex);
     const branchName = tab.branch || tab.name || t("app.untitled");
     const colorId = tabColors
@@ -109,6 +109,7 @@ function GroupTabList({
           ...styles.row,
           ...(nested ? styles.nestedRow : {}),
           ...(isActive ? styles.rowActive : {}),
+          ...(tab.is_open === false ? styles.rowClosed : {}),
         }}
         draggable
         onDragStart={(event) => {
@@ -136,9 +137,15 @@ function GroupTabList({
             ...styles.tabButton,
             ...getColorBorder(colorId),
           }}
-          onClick={() => {
-            onTabClick(originalIndex);
-            onRequestClose();
+          onClick={async (event) => {
+            const anchorRect = event.currentTarget.getBoundingClientRect();
+            if (tab.is_open === false) {
+              await onRequestClose();
+            }
+            onTabClick(originalIndex, anchorRect);
+            if (tab.is_open !== false) {
+              void onRequestClose();
+            }
           }}
           onContextMenu={(event) => {
             event.preventDefault();
@@ -152,9 +159,16 @@ function GroupTabList({
               <span style={styles.branchName}>⑂ {tab.branch}</span>
             )}
           </span>
-          <span style={styles.editorName}>
-            {EDITOR_DISPLAY_NAMES[tab.bundle_id] || tab.editor_name}
-          </span>
+          {tab.is_open !== false && (
+            <span style={styles.editorName}>
+              {EDITOR_DISPLAY_NAMES[tab.bundle_id] || tab.editor_name}
+            </span>
+          )}
+          {tab.is_open === false && (
+            <span style={tab.open_error ? styles.errorLabel : styles.closedLabel}>
+              {t(tab.open_error ? "tabBar.openFailed" : "tabBar.closedLabel")}
+            </span>
+          )}
           {status === "waiting" && <span style={styles.badgeWaiting} />}
           {status === "generating" && <span style={styles.badgeGenerating} className="pulse-animation" />}
         </button>
@@ -162,8 +176,8 @@ function GroupTabList({
           type="button"
           style={styles.closeButton}
           onClick={() => onCloseTab(originalIndex)}
-          aria-label={t("worktree.closeBranch", { branch: branchName })}
-          title={t("tabBar.closeTooltip")}
+          aria-label={t("tabBar.removeTooltip")}
+          title={t("tabBar.removeTooltip")}
         >
           ×
         </button>
@@ -180,7 +194,7 @@ function GroupTabList({
       onKeyDown={(event) => {
         if (event.key === "Escape") {
           event.stopPropagation();
-          onRequestClose();
+          void onRequestClose();
         }
       }}
     >
@@ -188,7 +202,9 @@ function GroupTabList({
         if (item.type === "tab") return renderTabRow(item.entry);
 
         const indices = item.entries.map((entry) => entry.originalIndex);
-        const activeEntry = item.entries.find((entry) => entry.originalIndex === activeIndex);
+        const activeEntry = item.entries.find(
+          (entry) => entry.tab.is_open !== false && entry.originalIndex === activeIndex,
+        );
         const isExpanded = expandedRepositories.has(item.key);
         const isParentActive = Boolean(activeEntry) && !isExpanded;
         const preferredIndex = activeEntry?.originalIndex ?? indices[0];
@@ -294,6 +310,9 @@ const styles: Record<string, React.CSSProperties> = {
   rowActive: {
     background: "rgba(0, 122, 255, 0.18)",
   },
+  rowClosed: {
+    opacity: 0.55,
+  },
   nestedRow: {
     marginTop: "2px",
   },
@@ -347,6 +366,16 @@ const styles: Record<string, React.CSSProperties> = {
   editorName: {
     flexShrink: 0,
     color: "rgba(255, 255, 255, 0.5)",
+    fontSize: "10px",
+  },
+  closedLabel: {
+    flexShrink: 0,
+    color: "rgba(255, 255, 255, 0.5)",
+    fontSize: "10px",
+  },
+  errorLabel: {
+    flexShrink: 0,
+    color: "#ff6961",
     fontSize: "10px",
   },
   closeButton: {

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -9,8 +9,10 @@ const blend = (base: number, color: number, ratio: number) =>
 interface TabProps {
   name: string;
   isActive: boolean;
+  isOpen: boolean;
+  hasOpenError: boolean;
   isDragging: boolean;
-  onClick: (index: number) => void;
+  onClick: (index: number, anchorRect: DOMRect) => void;
   onClose: (index: number) => void;
   onDragStart: (index: number) => void;
   onDragEnd: () => void;
@@ -23,7 +25,7 @@ interface TabProps {
   branch?: string;
 }
 
-const Tab = memo(function Tab({ name, isActive, isDragging, onClick, onClose, onDragStart, onDragEnd, onDragOver, onDrop, index, claudeStatus, colorId, onContextMenu, branch }: TabProps) {
+const Tab = memo(function Tab({ name, isActive, isOpen, hasOpenError, isDragging, onClick, onClose, onDragStart, onDragEnd, onDragOver, onDrop, index, claudeStatus, colorId, onContextMenu, branch }: TabProps) {
   const { t } = useTranslation();
   const [isHovered, setIsHovered] = useState(false);
 
@@ -52,13 +54,14 @@ const Tab = memo(function Tab({ name, isActive, isDragging, onClick, onClose, on
       style={{
         ...styles.tab,
         ...(isActive ? styles.tabActive : {}),
+        ...(!isOpen ? styles.tabClosed : {}),
         ...(isHovered ? styles.tabHover : {}),
         ...(isDragging ? styles.tabDragging : {}),
         ...colorStyle,
       }}
-      onClick={() => {
+      onClick={(event) => {
         setIsHovered(false);
-        onClick(index);
+        onClick(index, event.currentTarget.getBoundingClientRect());
       }}
       onMouseDown={(e) => e.stopPropagation()}
       onMouseEnter={() => setIsHovered(true)}
@@ -87,9 +90,22 @@ const Tab = memo(function Tab({ name, isActive, isDragging, onClick, onClose, on
         e.preventDefault();
         onDrop(index);
       }}
-      title={shortcutKey ? `${displayName} (${shortcutKey})` : displayName}
+      title={!isOpen
+        ? t("tabBar.closedTooltip", { name: displayName })
+        : shortcutKey
+          ? `${displayName} (${shortcutKey})`
+          : displayName}
       data-tab-index={index}
     >
+      {!isOpen && (
+        <span
+          aria-label={hasOpenError ? t("tabBar.openFailed") : t("tabBar.closedLabel")}
+          title={hasOpenError ? t("tabBar.openFailed") : undefined}
+          style={hasOpenError ? styles.errorIndicator : styles.closedIndicator}
+        >
+          {hasOpenError ? "!" : ""}
+        </span>
+      )}
       <div style={styles.tabTextContent}>
         <span style={styles.tabName}>{displayName}</span>
         {branch && (
@@ -107,7 +123,8 @@ const Tab = memo(function Tab({ name, isActive, isDragging, onClick, onClose, on
           e.stopPropagation();
           onClose(index);
         }}
-        title={t("tabBar.closeTooltip")}
+        aria-label={t("tabBar.removeTooltip")}
+        title={t("tabBar.removeTooltip")}
       >
         ×
       </button>
@@ -134,6 +151,9 @@ const styles: Record<string, React.CSSProperties> = {
   tabActive: {
     background: "#484848",
     borderBottom: "2px solid #007aff",
+  },
+  tabClosed: {
+    opacity: 0.55,
   },
   tabHover: {
     background: "#333333",
@@ -177,6 +197,26 @@ const styles: Record<string, React.CSSProperties> = {
     alignItems: "center",
     justifyContent: "center",
     transition: "opacity 0.15s, background 0.15s",
+    flexShrink: 0,
+  },
+  closedIndicator: {
+    width: "7px",
+    height: "7px",
+    border: "1px solid rgba(255, 255, 255, 0.65)",
+    borderRadius: "50%",
+    flexShrink: 0,
+  },
+  errorIndicator: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "12px",
+    height: "12px",
+    borderRadius: "50%",
+    background: "#ff3b30",
+    color: "#ffffff",
+    fontSize: "9px",
+    fontWeight: 700,
     flexShrink: 0,
   },
   badgeWaiting: {

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -59,15 +59,18 @@ function setup(
     tabs,
     activeIndex: 0,
     onTabClick: vi.fn(),
-    onNewTab: vi.fn(),
+    onNewTab: vi.fn().mockResolvedValue(true),
     onCloseTab: vi.fn(),
     onReorder: vi.fn(),
     onReorderByVisual: vi.fn(),
     history: [],
     showAddMenu: false,
     onAddMenuOpen: vi.fn(),
-    onAddMenuClose: vi.fn(),
-    onHistorySelect: vi.fn(),
+    onAddMenuClose: vi.fn().mockResolvedValue(undefined),
+    onEditorPickerOpen: vi.fn().mockResolvedValue(undefined),
+    onEditorPickerClose: vi.fn().mockResolvedValue(undefined),
+    onHistorySelect: vi.fn().mockResolvedValue(true),
+    onClosedTabOpen: vi.fn().mockResolvedValue(true),
     onHistoryClear: vi.fn(),
     onColorPickerOpen: vi.fn().mockResolvedValue(undefined),
     onColorPickerClose: vi.fn(),
@@ -124,6 +127,26 @@ describe("TabBar repository grouping", () => {
     expect(within(group as HTMLElement).getByRole("button", {
       name: "worktree.openBranches",
     })).toBeInTheDocument();
+  });
+
+  it("restores a legacy group assignment left under another editor", () => {
+    const movedTab = {
+      ...standaloneWindow,
+      bundle_id: "com.microsoft.VSCode",
+      editor_name: "VSCode",
+      is_open: false,
+    };
+    setup(
+      {},
+      "horizontal",
+      [movedTab],
+      { [`${standaloneWindow.bundle_id}:${standaloneWindow.name}`]: "medii" },
+    );
+
+    const group = screen.getByRole("button", { name: "medii" })
+      .closest(".tab-group");
+    expect(within(group as HTMLElement).getByTitle("tabBar.closedTooltip"))
+      .toBeInTheDocument();
   });
 
   it("assigns every repository window from the parent context menu", async () => {
@@ -209,7 +232,7 @@ describe("TabBar repository grouping", () => {
     fireEvent.click(groupButton);
     fireEvent.click(screen.getByRole("menuitem", { name: /medii-e-consult-front/ }));
 
-    fireEvent.click(screen.getAllByRole("button", { name: "worktree.closeBranch" })[2]);
+    fireEvent.click(screen.getAllByRole("button", { name: "tabBar.removeTooltip" })[2]);
     expect(props.onCloseTab).toHaveBeenCalledWith(2);
     rerenderTabs([cursorWindow, vscodeWorktree]);
 
@@ -232,5 +255,48 @@ describe("TabBar repository grouping", () => {
     expect(props.onTabClick).toHaveBeenCalledWith(1);
     expect(props.onWorktreeMenuClose).toHaveBeenCalledOnce();
     expect(screen.queryByRole("menu", { name: "group.tabList" })).not.toBeInTheDocument();
+  });
+
+  it("shows an editor picker when clicking a closed tab", async () => {
+    const closedTab = { ...standaloneWindow, is_open: false };
+    const { props } = setup({}, "horizontal", [closedTab], {});
+
+    const tab = screen.getByTitle("tabBar.closedTooltip");
+    expect(tab).toHaveStyle({ opacity: "0.55" });
+    expect(screen.getByLabelText("tabBar.closedLabel")).toBeInTheDocument();
+
+    fireEvent.click(tab);
+    expect(
+      await screen.findByRole("dialog", { name: "history.chooseEditor" }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cursor" }));
+    expect(props.onClosedTabOpen).toHaveBeenCalledWith(
+      0,
+      "com.todesktop.230313mzl4w4u92",
+      undefined,
+    );
+    expect(props.onTabClick).not.toHaveBeenCalled();
+  });
+
+  it("preserves an inherited group when opening a closed worktree tab", async () => {
+    const closedWorktree = { ...vscodeWorktree, is_open: false };
+    const { props } = setup(
+      {},
+      "list",
+      [cursorWindow, closedWorktree],
+      { [windowKey(cursorWindow)]: "medii" },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /medii/ }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /medii-e-consult-front/ }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /feature\/search/ }));
+    fireEvent.click(await screen.findByRole("button", { name: "Zed" }));
+
+    expect(props.onClosedTabOpen).toHaveBeenCalledWith(
+      1,
+      "dev.zed.Zed",
+      "medii",
+    );
   });
 });

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { useState, type ComponentProps } from "react";
 import type { EditorWindow } from "../types/editor";
 import { repositoryColorKey, windowKey } from "../utils/store";
 import TabBar from "./TabBar";
@@ -45,6 +46,21 @@ const standaloneWindow: EditorWindow = {
   editor_name: "Cursor",
 };
 
+function StatefulTabBar(props: ComponentProps<typeof TabBar>) {
+  const [showAddMenu, setShowAddMenu] = useState(props.showAddMenu);
+
+  return (
+    <TabBar
+      {...props}
+      showAddMenu={showAddMenu}
+      onAddMenuHandoff={() => {
+        props.onAddMenuHandoff();
+        setShowAddMenu(false);
+      }}
+    />
+  );
+}
+
 function setup(
   tabColors: Record<string, string | null> = {},
   tabLayout: "horizontal" | "list" = "horizontal",
@@ -52,6 +68,7 @@ function setup(
   groupAssignments: Record<string, string | null> = {
     [windowKey(cursorWindow)]: "medii",
   },
+  overrides: Partial<ComponentProps<typeof TabBar>> = {},
 ) {
   const onAssignTabsToGroup = vi.fn();
   const onColorChange = vi.fn();
@@ -67,6 +84,7 @@ function setup(
     showAddMenu: false,
     onAddMenuOpen: vi.fn(),
     onAddMenuClose: vi.fn().mockResolvedValue(undefined),
+    onAddMenuHandoff: vi.fn(),
     onEditorPickerOpen: vi.fn().mockResolvedValue(undefined),
     onEditorPickerClose: vi.fn().mockResolvedValue(undefined),
     onHistorySelect: vi.fn().mockResolvedValue(true),
@@ -96,15 +114,16 @@ function setup(
     onTabContextMenuClose: vi.fn().mockResolvedValue(undefined),
     onWorktreeMenuOpen: vi.fn().mockResolvedValue(undefined),
     onWorktreeMenuClose: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
   };
 
-  const view = render(<TabBar {...props} />);
+  const view = render(<StatefulTabBar {...props} />);
   return {
     props,
     onAssignTabsToGroup,
     onColorChange,
     rerenderTabs: (nextTabs: EditorWindow[]) => {
-      view.rerender(<TabBar {...props} tabs={nextTabs} />);
+      view.rerender(<StatefulTabBar {...props} tabs={nextTabs} />);
     },
   };
 }
@@ -276,6 +295,58 @@ describe("TabBar repository grouping", () => {
       undefined,
     );
     expect(props.onTabClick).not.toHaveBeenCalled();
+  });
+
+  it("hands off a recent project to the editor picker without resizing", async () => {
+    const historyEntry = {
+      name: "sample-project",
+      path: "/Users/test/sample-project",
+      timestamp: Date.now(),
+    };
+    const { props } = setup(
+      {},
+      "horizontal",
+      [standaloneWindow],
+      {},
+      {
+        history: [historyEntry],
+        showAddMenu: true,
+      },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^sample-project/ }));
+
+    expect(
+      await screen.findByRole("dialog", { name: "history.chooseEditor" }),
+    ).toBeInTheDocument();
+    expect(props.onAddMenuHandoff).toHaveBeenCalledOnce();
+    expect(props.onAddMenuClose).not.toHaveBeenCalled();
+    expect(props.onEditorPickerOpen).not.toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: /^sample-project/ })).not.toBeInTheDocument();
+  });
+
+  it("hands off a new window to the editor picker without resizing", async () => {
+    const { props } = setup(
+      {},
+      "horizontal",
+      [standaloneWindow],
+      {},
+      {
+        showAddMenu: true,
+      },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /history\.newWindow/ }));
+
+    expect(
+      await screen.findByRole("dialog", { name: "history.chooseEditor" }),
+    ).toBeInTheDocument();
+    expect(props.onAddMenuHandoff).toHaveBeenCalledOnce();
+    expect(props.onAddMenuClose).not.toHaveBeenCalled();
+    expect(props.onEditorPickerOpen).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("button", { name: /history\.newWindow/ }),
+    ).not.toBeInTheDocument();
   });
 
   it("preserves an inherited group when opening a closed worktree tab", async () => {

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -129,7 +129,7 @@ describe("TabBar repository grouping", () => {
     })).toBeInTheDocument();
   });
 
-  it("restores a legacy group assignment left under another editor", () => {
+  it("does not inherit a same-named legacy group assignment from another editor", () => {
     const movedTab = {
       ...standaloneWindow,
       bundle_id: "com.microsoft.VSCode",
@@ -143,10 +143,9 @@ describe("TabBar repository grouping", () => {
       { [`${standaloneWindow.bundle_id}:${standaloneWindow.name}`]: "medii" },
     );
 
-    const group = screen.getByRole("button", { name: "medii" })
-      .closest(".tab-group");
-    expect(within(group as HTMLElement).getByTitle("tabBar.closedTooltip"))
-      .toBeInTheDocument();
+    expect(
+      screen.getByTitle("tabBar.closedTooltip").closest(".tab-group"),
+    ).toBeNull();
   });
 
   it("assigns every repository window from the parent context menu", async () => {

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -6,7 +6,6 @@ import GroupTabList from "./GroupTabList";
 import ColorPicker from "./ColorPicker";
 import AddTabMenu from "./AddTabMenu";
 import EditorPicker from "./EditorPicker";
-import { PROJECT_EDITOR_BUNDLE_IDS } from "../types/editor";
 import type { EditorWindow, ClaudeStatus, HistoryEntry, GroupDefinition, GroupAssignment, ProjectEditorBundleId, TabColorMap, TabLayout } from "../types/editor";
 import { getWindowScopedValue, legacyWindowKey, projectPathMatchesWindow, repositoryColorKey, runtimeWindowKey, windowKey } from "../utils/store";
 import { getColorById } from "../constants/tabColors";
@@ -98,21 +97,12 @@ const getListRowCount = (
 const getTabGroupId = (
   assignments: GroupAssignment,
   tab: EditorWindow,
-): string | null | undefined => {
-  const directGroupId = getWindowScopedValue(
+): string | null | undefined =>
+  getWindowScopedValue(
     assignments,
     tab,
     legacyWindowKey(tab),
   );
-  if (directGroupId !== undefined) return directGroupId;
-
-  const legacyGroupIds = new Set(
-    PROJECT_EDITOR_BUNDLE_IDS
-      .map((bundleId) => assignments[`${bundleId}:${tab.name}`])
-      .filter((groupId): groupId is string => Boolean(groupId)),
-  );
-  return legacyGroupIds.size === 1 ? [...legacyGroupIds][0] : undefined;
-};
 
 function TabBar(props: TabBarProps) {
   const { tabs, activeIndex, onTabClick, onNewTab, onCloseTab, onReorder, onReorderByVisual, claudeStatuses, tabColors, onColorChange, showBranch, tabLayout, history, showAddMenu, onAddMenuOpen, onAddMenuClose, onEditorPickerOpen, onEditorPickerClose, onHistorySelect, onClosedTabOpen, onHistoryClear, onColorPickerOpen, onColorPickerClose, groups, groupAssignments, collapsedGroups, onAddGroup, onUpdateGroup, onDeleteGroup, onAssignTabsToGroup, onUnassignTabsFromGroup, onToggleGroupCollapse, onReorderGroups, groupColors, onSetGroupColor, onTabContextMenuOpen, onTabContextMenuClose, onWorktreeMenuOpen, onWorktreeMenuClose } = props;

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -28,6 +28,7 @@ interface TabBarProps {
   showAddMenu: boolean;
   onAddMenuOpen: () => void;
   onAddMenuClose: () => Promise<void>;
+  onAddMenuHandoff: () => void;
   onEditorPickerOpen: () => Promise<void>;
   onEditorPickerClose: () => Promise<void>;
   onHistorySelect: (entry: HistoryEntry, bundleId: ProjectEditorBundleId) => Promise<boolean>;
@@ -105,7 +106,7 @@ const getTabGroupId = (
   );
 
 function TabBar(props: TabBarProps) {
-  const { tabs, activeIndex, onTabClick, onNewTab, onCloseTab, onReorder, onReorderByVisual, claudeStatuses, tabColors, onColorChange, showBranch, tabLayout, history, showAddMenu, onAddMenuOpen, onAddMenuClose, onEditorPickerOpen, onEditorPickerClose, onHistorySelect, onClosedTabOpen, onHistoryClear, onColorPickerOpen, onColorPickerClose, groups, groupAssignments, collapsedGroups, onAddGroup, onUpdateGroup, onDeleteGroup, onAssignTabsToGroup, onUnassignTabsFromGroup, onToggleGroupCollapse, onReorderGroups, groupColors, onSetGroupColor, onTabContextMenuOpen, onTabContextMenuClose, onWorktreeMenuOpen, onWorktreeMenuClose } = props;
+  const { tabs, activeIndex, onTabClick, onNewTab, onCloseTab, onReorder, onReorderByVisual, claudeStatuses, tabColors, onColorChange, showBranch, tabLayout, history, showAddMenu, onAddMenuOpen, onAddMenuClose, onAddMenuHandoff, onEditorPickerOpen, onEditorPickerClose, onHistorySelect, onClosedTabOpen, onHistoryClear, onColorPickerOpen, onColorPickerClose, groups, groupAssignments, collapsedGroups, onAddGroup, onUpdateGroup, onDeleteGroup, onAssignTabsToGroup, onUnassignTabsFromGroup, onToggleGroupCollapse, onReorderGroups, groupColors, onSetGroupColor, onTabContextMenuOpen, onTabContextMenuClose, onWorktreeMenuOpen, onWorktreeMenuClose } = props;
   const { t } = useTranslation();
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
   const [colorPickerTarget, setColorPickerTarget] = useState<{ key: string; currentColorId: string | null } | null>(null);
@@ -753,7 +754,9 @@ function TabBar(props: TabBarProps) {
         <AddTabMenu
           entries={history}
           onNewWindow={async (anchorRect) => {
-            await onEditorPickerOpen();
+            onAddMenuHandoff();
+            // Finish the current input event before mounting the next overlay.
+            await new Promise<void>((resolve) => setTimeout(resolve, 0));
             setEditorPickerTarget({
               kind: "new-window",
               name: t("history.newWindow"),
@@ -761,7 +764,9 @@ function TabBar(props: TabBarProps) {
             });
           }}
           onSelectHistory={async (entry, anchorRect) => {
-            await onEditorPickerOpen();
+            onAddMenuHandoff();
+            // Finish the current input event before mounting the next overlay.
+            await new Promise<void>((resolve) => setTimeout(resolve, 0));
             setEditorPickerTarget({
               kind: "history",
               name: entry.name,

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -5,7 +5,9 @@ import WorktreeTab from "./WorktreeTab";
 import GroupTabList from "./GroupTabList";
 import ColorPicker from "./ColorPicker";
 import AddTabMenu from "./AddTabMenu";
-import type { EditorWindow, ClaudeStatus, HistoryEntry, GroupDefinition, GroupAssignment, TabColorMap, TabLayout } from "../types/editor";
+import EditorPicker from "./EditorPicker";
+import { PROJECT_EDITOR_BUNDLE_IDS } from "../types/editor";
+import type { EditorWindow, ClaudeStatus, HistoryEntry, GroupDefinition, GroupAssignment, ProjectEditorBundleId, TabColorMap, TabLayout } from "../types/editor";
 import { getWindowScopedValue, legacyWindowKey, projectPathMatchesWindow, repositoryColorKey, runtimeWindowKey, windowKey } from "../utils/store";
 import { getColorById } from "../constants/tabColors";
 import { getInheritedRepositoryGroupId, groupRepositoryTabs, type TabEntry } from "../utils/repositoryTabs";
@@ -14,7 +16,7 @@ interface TabBarProps {
   tabs: EditorWindow[];
   activeIndex: number;
   onTabClick: (index: number) => void;
-  onNewTab: () => void;
+  onNewTab: (bundleId?: ProjectEditorBundleId) => Promise<boolean>;
   onCloseTab: (index: number) => void;
   onReorder: (fromIndex: number, toIndex: number) => void;
   onReorderByVisual: (visualOrder: number[]) => void;
@@ -26,8 +28,15 @@ interface TabBarProps {
   history: HistoryEntry[];
   showAddMenu: boolean;
   onAddMenuOpen: () => void;
-  onAddMenuClose: () => void;
-  onHistorySelect: (entry: HistoryEntry) => void;
+  onAddMenuClose: () => Promise<void>;
+  onEditorPickerOpen: () => Promise<void>;
+  onEditorPickerClose: () => Promise<void>;
+  onHistorySelect: (entry: HistoryEntry, bundleId: ProjectEditorBundleId) => Promise<boolean>;
+  onClosedTabOpen: (
+    index: number,
+    bundleId: ProjectEditorBundleId,
+    groupId?: string,
+  ) => Promise<boolean>;
   onHistoryClear: () => void;
   onColorPickerOpen: () => Promise<void>;
   onColorPickerClose: () => void;
@@ -48,6 +57,17 @@ interface TabBarProps {
   onWorktreeMenuOpen: (rowCount: number) => Promise<void>;
   onWorktreeMenuClose: () => Promise<void>;
 }
+
+type EditorPickerTarget =
+  | { kind: "new-window"; name: string; anchorRect: DOMRect }
+  | { kind: "history"; name: string; entry: HistoryEntry; anchorRect: DOMRect }
+  | {
+      kind: "closed-tab";
+      name: string;
+      tabKey: string;
+      groupId?: string;
+      anchorRect: DOMRect;
+    };
 
 const toRgba = (rgb: { r: number; g: number; b: number }, alpha: number) =>
   `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${alpha})`;
@@ -75,8 +95,27 @@ const getListRowCount = (
   );
 };
 
+const getTabGroupId = (
+  assignments: GroupAssignment,
+  tab: EditorWindow,
+): string | null | undefined => {
+  const directGroupId = getWindowScopedValue(
+    assignments,
+    tab,
+    legacyWindowKey(tab),
+  );
+  if (directGroupId !== undefined) return directGroupId;
+
+  const legacyGroupIds = new Set(
+    PROJECT_EDITOR_BUNDLE_IDS
+      .map((bundleId) => assignments[`${bundleId}:${tab.name}`])
+      .filter((groupId): groupId is string => Boolean(groupId)),
+  );
+  return legacyGroupIds.size === 1 ? [...legacyGroupIds][0] : undefined;
+};
+
 function TabBar(props: TabBarProps) {
-  const { tabs, activeIndex, onTabClick, onNewTab, onCloseTab, onReorder, onReorderByVisual, claudeStatuses, tabColors, onColorChange, showBranch, tabLayout, history, showAddMenu, onAddMenuOpen, onAddMenuClose, onHistorySelect, onHistoryClear, onColorPickerOpen, onColorPickerClose, groups, groupAssignments, collapsedGroups, onAddGroup, onUpdateGroup, onDeleteGroup, onAssignTabsToGroup, onUnassignTabsFromGroup, onToggleGroupCollapse, onReorderGroups, groupColors, onSetGroupColor, onTabContextMenuOpen, onTabContextMenuClose, onWorktreeMenuOpen, onWorktreeMenuClose } = props;
+  const { tabs, activeIndex, onTabClick, onNewTab, onCloseTab, onReorder, onReorderByVisual, claudeStatuses, tabColors, onColorChange, showBranch, tabLayout, history, showAddMenu, onAddMenuOpen, onAddMenuClose, onEditorPickerOpen, onEditorPickerClose, onHistorySelect, onClosedTabOpen, onHistoryClear, onColorPickerOpen, onColorPickerClose, groups, groupAssignments, collapsedGroups, onAddGroup, onUpdateGroup, onDeleteGroup, onAssignTabsToGroup, onUnassignTabsFromGroup, onToggleGroupCollapse, onReorderGroups, groupColors, onSetGroupColor, onTabContextMenuOpen, onTabContextMenuClose, onWorktreeMenuOpen, onWorktreeMenuClose } = props;
   const { t } = useTranslation();
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
   const [colorPickerTarget, setColorPickerTarget] = useState<{ key: string; currentColorId: string | null } | null>(null);
@@ -93,6 +132,7 @@ function TabBar(props: TabBarProps) {
   const [openGroupId, setOpenGroupId] = useState<string | null>(null);
   const [groupListAnchorLeft, setGroupListAnchorLeft] = useState(8);
   const [expandedRepositories, setExpandedRepositories] = useState<Set<string>>(() => new Set());
+  const [editorPickerTarget, setEditorPickerTarget] = useState<EditorPickerTarget | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const tabsWrapperRef = useRef<HTMLDivElement>(null);
   const addButtonRef = useRef<HTMLButtonElement>(null);
@@ -128,10 +168,48 @@ function TabBar(props: TabBarProps) {
     // Could be used for visual feedback in the future
   }, []);
 
-  // Stable callback that receives index from Tab component
-  const handleTabClick = useCallback((index: number) => {
+  const handleTabClick = useCallback(async (
+    index: number,
+    anchorRect: DOMRect,
+    groupId?: string,
+  ) => {
+    const tab = tabs[index];
+    if (tab?.is_open === false) {
+      await onEditorPickerOpen();
+      setEditorPickerTarget({
+        kind: "closed-tab",
+        name: tab.name,
+        tabKey: windowKey(tab),
+        groupId,
+        anchorRect,
+      });
+      return;
+    }
     onTabClick(index);
-  }, [onTabClick]);
+  }, [onEditorPickerOpen, onTabClick, tabs]);
+
+  const closeEditorPicker = useCallback(async () => {
+    setEditorPickerTarget(null);
+    await onEditorPickerClose();
+  }, [onEditorPickerClose]);
+
+  const handleEditorSelect = useCallback(
+    (bundleId: ProjectEditorBundleId) => {
+      if (!editorPickerTarget) return Promise.resolve(false);
+      if (editorPickerTarget.kind === "new-window") {
+        return onNewTab(bundleId);
+      }
+      if (editorPickerTarget.kind === "history") {
+        return onHistorySelect(editorPickerTarget.entry, bundleId);
+      }
+
+      const index = tabs.findIndex((tab) => windowKey(tab) === editorPickerTarget.tabKey);
+      return index >= 0
+        ? onClosedTabOpen(index, bundleId, editorPickerTarget.groupId)
+        : Promise.resolve(false);
+    },
+    [editorPickerTarget, onClosedTabOpen, onHistorySelect, onNewTab, tabs],
+  );
 
   const handleCloseTab = useCallback((index: number) => {
     onCloseTab(index);
@@ -159,10 +237,10 @@ function TabBar(props: TabBarProps) {
     });
   }, [onTabContextMenuOpen]);
 
-  const closeGroupList = useCallback(() => {
+  const closeGroupList = useCallback(async () => {
     if (openGroupId === null) return;
     setOpenGroupId(null);
-    void onWorktreeMenuClose();
+    await onWorktreeMenuClose();
   }, [onWorktreeMenuClose, openGroupId]);
 
   const toggleRepositoryExpansion = useCallback((repositoryId: string) => {
@@ -180,7 +258,7 @@ function TabBar(props: TabBarProps) {
   const toggleGroupList = useCallback((groupId: string, entries: TabEntry[], rect: DOMRect) => {
     if (entries.length === 0) return;
     if (openGroupId === groupId) {
-      closeGroupList();
+      void closeGroupList();
       return;
     }
     setGroupListAnchorLeft(rect.left);
@@ -361,7 +439,7 @@ function TabBar(props: TabBarProps) {
     for (const item of groupRepositoryTabs(allEntries)) {
       if (item.type !== "repository") continue;
       const inheritedGroupId = getInheritedRepositoryGroupId(item.entries, ({ tab }) => {
-        const groupId = getWindowScopedValue(groupAssignments, tab, legacyWindowKey(tab));
+        const groupId = getTabGroupId(groupAssignments, tab);
         return groupId && groupIds.has(groupId) ? groupId : null;
       });
       for (const { originalIndex } of item.entries) {
@@ -370,7 +448,7 @@ function TabBar(props: TabBarProps) {
     }
 
     tabs.forEach((tab, index) => {
-      const assignedGroupId = getWindowScopedValue(groupAssignments, tab, legacyWindowKey(tab));
+      const assignedGroupId = getTabGroupId(groupAssignments, tab);
       const groupId = repositoryGroupByIndex.has(index)
         ? repositoryGroupByIndex.get(index)
         : assignedGroupId;
@@ -432,13 +510,19 @@ function TabBar(props: TabBarProps) {
     void onWorktreeMenuClose();
   }, [onWorktreeMenuClose, openGroupId, tabLayout]);
 
-  const renderTab = (tab: EditorWindow, originalIndex: number) => (
+  const renderTab = (
+    tab: EditorWindow,
+    originalIndex: number,
+    groupId?: string,
+  ) => (
     <Tab
       key={runtimeWindowKey(tab)}
       name={tab.name}
-      isActive={originalIndex === activeIndex}
+      isActive={tab.is_open !== false && originalIndex === activeIndex}
+      isOpen={tab.is_open !== false}
+      hasOpenError={tab.open_error === true}
       isDragging={originalIndex === draggedIndex}
-      onClick={handleTabClick}
+      onClick={(index, anchorRect) => handleTabClick(index, anchorRect, groupId)}
       onClose={handleCloseTab}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
@@ -452,9 +536,12 @@ function TabBar(props: TabBarProps) {
     />
   );
 
-  const renderRepositoryTabs = (entries: TabEntry[]) => groupRepositoryTabs(entries).map((item) => {
+  const renderRepositoryTabs = (
+    entries: TabEntry[],
+    groupId?: string,
+  ) => groupRepositoryTabs(entries).map((item) => {
     if (item.type === "tab") {
-      return renderTab(item.entry.tab, item.entry.originalIndex);
+      return renderTab(item.entry.tab, item.entry.originalIndex, groupId);
     }
 
     const statuses = new Map(
@@ -471,7 +558,7 @@ function TabBar(props: TabBarProps) {
         activeIndex={activeIndex}
         statuses={statuses}
         colorId={tabColors?.[repositoryColorKey(item.key)] ?? null}
-        onTabClick={handleTabClick}
+        onTabClick={(index, anchorRect) => handleTabClick(index, anchorRect, groupId)}
         onCloseTab={handleCloseTab}
         onMenuOpen={onWorktreeMenuOpen}
         onMenuClose={onWorktreeMenuClose}
@@ -521,7 +608,9 @@ function TabBar(props: TabBarProps) {
           const groupTabs = groupedTabsMap.get(group.id) || [];
           const isCollapsed = collapsedGroups.has(group.id);
           const isListOpen = tabLayout === "list" && openGroupId === group.id;
-          const activeGroupEntry = groupTabs.find(({ originalIndex }) => originalIndex === activeIndex);
+          const activeGroupEntry = groupTabs.find(
+            ({ tab, originalIndex }) => tab.is_open !== false && originalIndex === activeIndex,
+          );
           const groupColor = getColorById(groupColors[group.id]);
           const groupContainerStyle: React.CSSProperties = {
             ...styles.groupContainer,
@@ -601,7 +690,9 @@ function TabBar(props: TabBarProps) {
               )}
 
               {/* Group tabs (hidden when collapsed) */}
-              {tabLayout === "horizontal" && !isCollapsed && renderRepositoryTabs(groupTabs)}
+              {tabLayout === "horizontal" &&
+                !isCollapsed &&
+                renderRepositoryTabs(groupTabs, group.id)}
             </div>
           );
         })}
@@ -612,9 +703,13 @@ function TabBar(props: TabBarProps) {
         <button
           ref={addButtonRef}
           style={styles.addButton}
-          onClick={onAddMenuOpen}
+          onClick={() => {
+            setEditorPickerTarget(null);
+            onAddMenuOpen();
+          }}
           onMouseDown={(e) => e.stopPropagation()}
           title={t("tabBar.newEditorTooltip")}
+          aria-label={t("tabBar.newEditorTooltip")}
         >
           +
         </button>
@@ -630,7 +725,9 @@ function TabBar(props: TabBarProps) {
           showBranch={showBranch !== false}
           anchorLeft={groupListAnchorLeft}
           expandedRepositories={expandedRepositories}
-          onTabClick={handleTabClick}
+          onTabClick={(index, anchorRect) =>
+            handleTabClick(index, anchorRect, openGroup.id)
+          }
           onCloseTab={handleCloseTab}
           onRequestClose={closeGroupList}
           onTabContextMenu={handleListTabContextMenu}
@@ -665,14 +762,35 @@ function TabBar(props: TabBarProps) {
       {showAddMenu && (
         <AddTabMenu
           entries={history}
-          currentWindows={tabs}
-          onNewWindow={() => {
-            onNewTab();
+          onNewWindow={async (anchorRect) => {
+            await onEditorPickerOpen();
+            setEditorPickerTarget({
+              kind: "new-window",
+              name: t("history.newWindow"),
+              anchorRect,
+            });
           }}
-          onSelectHistory={onHistorySelect}
+          onSelectHistory={async (entry, anchorRect) => {
+            await onEditorPickerOpen();
+            setEditorPickerTarget({
+              kind: "history",
+              name: entry.name,
+              entry,
+              anchorRect,
+            });
+          }}
           onClearHistory={onHistoryClear}
           onClose={onAddMenuClose}
           anchorRef={addButtonRef}
+        />
+      )}
+
+      {editorPickerTarget && (
+        <EditorPicker
+          targetName={editorPickerTarget.name}
+          anchorRect={editorPickerTarget.anchorRect}
+          onSelect={handleEditorSelect}
+          onClose={() => void closeEditorPicker()}
         />
       )}
 

--- a/src/components/WorktreeTab.test.tsx
+++ b/src/components/WorktreeTab.test.tsx
@@ -96,7 +96,7 @@ describe("WorktreeTab", () => {
 
     fireEvent.click(screen.getByRole("menuitem", { name: /main/ }));
 
-    expect(props.onTabClick).toHaveBeenCalledWith(2);
+    expect(props.onTabClick).toHaveBeenCalledWith(2, expect.anything());
     expect(props.onMenuClose).toHaveBeenCalledOnce();
   });
 

--- a/src/components/WorktreeTab.tsx
+++ b/src/components/WorktreeTab.tsx
@@ -12,7 +12,7 @@ interface WorktreeTabProps {
   activeIndex: number;
   statuses: Map<number, ClaudeStatus | undefined>;
   colorId?: string | null;
-  onTabClick: (index: number) => void;
+  onTabClick: (index: number, anchorRect: DOMRect) => void;
   onCloseTab: (index: number) => void;
   onMenuOpen: (rowCount: number) => Promise<void>;
   onMenuClose: () => Promise<void>;
@@ -44,7 +44,8 @@ function WorktreeTab({
 
   const activeEntry = entries.find((entry) => entry.originalIndex === activeIndex);
   const contextEntry = activeEntry ?? entries[0];
-  const isActive = Boolean(activeEntry);
+  const isActive = Boolean(activeEntry && activeEntry.tab.is_open !== false);
+  const hasOpenWindow = entries.some((entry) => entry.tab.is_open !== false);
   const showEditorNames = new Set(entries.map((entry) => entry.tab.bundle_id)).size > 1;
   const hasWaiting = entries.some((entry) => statuses.get(entry.originalIndex) === "waiting");
   const hasGenerating = entries.some((entry) => statuses.get(entry.originalIndex) === "generating");
@@ -57,10 +58,10 @@ function WorktreeTab({
     colorStyle.background = `rgb(${blend(base, r, ratio)}, ${blend(base, g, ratio)}, ${blend(base, b, ratio)})`;
   }
 
-  const closeMenu = useCallback(() => {
+  const closeMenu = useCallback(async () => {
     if (!isOpen) return;
     setIsOpen(false);
-    void onMenuClose();
+    await onMenuClose();
   }, [isOpen, onMenuClose]);
 
   const openMenu = useCallback(() => {
@@ -77,7 +78,7 @@ function WorktreeTab({
 
   const toggleMenu = useCallback(() => {
     if (isOpen) {
-      closeMenu();
+      void closeMenu();
       return;
     }
     openMenu();
@@ -97,7 +98,7 @@ function WorktreeTab({
       const target = event.target as Node;
       if (rootRef.current?.contains(target)) return;
       if (menuRef.current?.contains(target)) return;
-      closeMenu();
+      void closeMenu();
     };
     document.addEventListener("mousedown", handlePointerDown, true);
     return () => document.removeEventListener("mousedown", handlePointerDown, true);
@@ -110,7 +111,7 @@ function WorktreeTab({
       onKeyDown={(event) => {
         if (event.key === "Escape" && isOpen) {
           event.stopPropagation();
-          closeMenu();
+          void closeMenu();
         }
       }}
       data-tab-index={isActive ? activeIndex : contextEntry.originalIndex}
@@ -121,6 +122,7 @@ function WorktreeTab({
           ...styles.tab,
           ...(isOpen && !isActive ? styles.tabOpen : {}),
           ...(isActive ? styles.tabActive : {}),
+          ...(!hasOpenWindow ? styles.tabClosed : {}),
           ...colorStyle,
         }}
         onMouseDown={(event) => {
@@ -163,24 +165,41 @@ function WorktreeTab({
           {entries.map(({ tab, originalIndex }) => {
             const status = statuses.get(originalIndex);
             const branchName = tab.branch || tab.name || t("app.untitled");
-            const rowActive = originalIndex === activeIndex;
+            const rowActive = tab.is_open !== false && originalIndex === activeIndex;
             return (
-              <div key={runtimeWindowKey(tab)} style={styles.row}>
+              <div
+                key={runtimeWindowKey(tab)}
+                style={{
+                  ...styles.row,
+                  ...(tab.is_open === false ? styles.rowClosed : {}),
+                }}
+              >
                 <button
                   type="button"
                   role="menuitem"
                   aria-current={rowActive ? "page" : undefined}
                   style={{ ...styles.branchButton, ...(rowActive ? styles.branchButtonActive : {}) }}
-                  onClick={() => {
-                    onTabClick(originalIndex);
-                    closeMenu();
+                  onClick={async (event) => {
+                    const anchorRect = event.currentTarget.getBoundingClientRect();
+                    if (tab.is_open === false) {
+                      await closeMenu();
+                    }
+                    onTabClick(originalIndex, anchorRect);
+                    if (tab.is_open !== false) {
+                      void closeMenu();
+                    }
                   }}
                 >
                   <span aria-hidden="true" style={styles.activeMarker}>{rowActive ? "●" : ""}</span>
                   <span style={styles.branchName}>⑂ {branchName}</span>
-                  {showEditorNames && (
+                  {showEditorNames && tab.is_open !== false && (
                     <span style={styles.editorName}>
                       {EDITOR_DISPLAY_NAMES[tab.bundle_id] || tab.editor_name}
+                    </span>
+                  )}
+                  {tab.is_open === false && (
+                    <span style={tab.open_error ? styles.errorLabel : styles.closedLabel}>
+                      {t(tab.open_error ? "tabBar.openFailed" : "tabBar.closedLabel")}
                     </span>
                   )}
                   {status === "waiting" && <span style={styles.badgeWaiting} />}
@@ -191,10 +210,10 @@ function WorktreeTab({
                   style={styles.closeButton}
                   onClick={() => {
                     onCloseTab(originalIndex);
-                    if (entries.length === 2) closeMenu();
+                    if (entries.length === 2) void closeMenu();
                   }}
-                  aria-label={t("worktree.closeBranch", { branch: branchName })}
-                  title={t("tabBar.closeTooltip")}
+                  aria-label={t("tabBar.removeTooltip")}
+                  title={t("tabBar.removeTooltip")}
                 >
                   ×
                 </button>
@@ -241,6 +260,9 @@ const styles: Record<string, React.CSSProperties> = {
   },
   tabOpen: {
     background: "#333333",
+  },
+  tabClosed: {
+    opacity: 0.55,
   },
   name: {
     minWidth: 0,
@@ -339,6 +361,19 @@ const styles: Record<string, React.CSSProperties> = {
     color: "rgba(255, 255, 255, 0.6)",
     cursor: "pointer",
     fontSize: "14px",
+  },
+  rowClosed: {
+    opacity: 0.55,
+  },
+  closedLabel: {
+    flexShrink: 0,
+    color: "rgba(255, 255, 255, 0.5)",
+    fontSize: "10px",
+  },
+  errorLabel: {
+    flexShrink: 0,
+    color: "#ff6961",
+    fontSize: "10px",
   },
   badgeWaiting: {
     ...badgeStyle,

--- a/src/hooks/useAppLifecycle.test.ts
+++ b/src/hooks/useAppLifecycle.test.ts
@@ -256,6 +256,22 @@ describe("useAppLifecycle", () => {
       expect(appWindow.setSize).toHaveBeenLastCalledWith(new LogicalSize(1920, 140));
     });
 
+    it("expands the window for the editor picker", async () => {
+      const appWindow = getCurrentWindow();
+      const { result } = setup({ "onboarding:completed": true });
+
+      await waitFor(() => {
+        expect(result.current.onboardingCompleted).toBe(true);
+      });
+      vi.mocked(appWindow.setSize).mockClear();
+
+      await act(async () => {
+        await result.current.handleEditorPickerOpen();
+      });
+
+      expect(appWindow.setSize).toHaveBeenLastCalledWith(new LogicalSize(1920, 456));
+    });
+
   });
 
   describe("app-activated event", () => {

--- a/src/hooks/useAppLifecycle.test.ts
+++ b/src/hooks/useAppLifecycle.test.ts
@@ -272,6 +272,58 @@ describe("useAppLifecycle", () => {
       expect(appWindow.setSize).toHaveBeenLastCalledWith(new LogicalSize(1920, 456));
     });
 
+    it("hands off the add menu without resizing the window", async () => {
+      const appWindow = getCurrentWindow();
+      const { result, params } = setup({ "onboarding:completed": true });
+
+      await waitFor(() => {
+        expect(result.current.onboardingCompleted).toBe(true);
+        expect(params.fetchWindowsRef.current).toHaveBeenCalled();
+      });
+      vi.mocked(appWindow.setMaxSize).mockClear();
+      vi.mocked(appWindow.setSize).mockClear();
+
+      act(() => {
+        result.current.handleAddMenuHandoff();
+      });
+
+      expect(params.setShowAddMenu).toHaveBeenCalledWith(false);
+      expect(appWindow.setMaxSize).not.toHaveBeenCalled();
+      expect(appWindow.setSize).not.toHaveBeenCalled();
+    });
+
+    it("does not finish an in-flight resize after the editor picker opens", async () => {
+      const appWindow = getCurrentWindow();
+      const { result, params } = setup({ "onboarding:completed": true });
+
+      await waitFor(() => {
+        expect(result.current.onboardingCompleted).toBe(true);
+        expect(params.fetchWindowsRef.current).toHaveBeenCalled();
+      });
+      vi.mocked(appWindow.setMaxSize).mockClear();
+      vi.mocked(appWindow.setSize).mockClear();
+
+      let resolveMonitor = (_monitor: Awaited<ReturnType<typeof currentMonitor>>) => {};
+      const monitorPromise = new Promise<Awaited<ReturnType<typeof currentMonitor>>>((resolve) => {
+        resolveMonitor = resolve;
+      });
+      vi.mocked(currentMonitor).mockReturnValueOnce(monitorPromise);
+
+      const resize = result.current.resizeTabBar();
+      act(() => {
+        result.current.handleAddMenuHandoff();
+      });
+      resolveMonitor({
+        position: { x: 0, y: 0 },
+        size: { width: 1920, height: 1080 },
+        scaleFactor: 1,
+      } as Awaited<ReturnType<typeof currentMonitor>>);
+      await resize;
+
+      expect(appWindow.setMaxSize).not.toHaveBeenCalled();
+      expect(appWindow.setSize).not.toHaveBeenCalled();
+    });
+
   });
 
   describe("app-activated event", () => {
@@ -345,6 +397,72 @@ describe("useAppLifecycle", () => {
       await waitFor(() => {
         expect(appWindow.setSize).toHaveBeenCalledWith(new LogicalSize(3440, 36));
       });
+    });
+
+    it("keeps the editor picker expanded when editor activation arrives after handoff", async () => {
+      const { result, listeners, params } = setup({ "onboarding:completed": true });
+
+      await waitFor(() => {
+        expect(result.current.onboardingCompleted).toBe(true);
+        expect(listeners.has("app-activated")).toBe(true);
+        expect(params.fetchWindowsRef.current).toHaveBeenCalled();
+      });
+
+      const appWindow = getCurrentWindow();
+      vi.mocked(appWindow.setMaxSize).mockClear();
+      vi.mocked(appWindow.setSize).mockClear();
+      vi.mocked(appWindow.setPosition).mockClear();
+      result.current.handleAddMenuHandoff();
+
+      const handler = listeners.get("app-activated") as unknown as (
+        event: { payload: AppActivationPayload },
+      ) => Promise<void>;
+      await act(async () => {
+        await handler({
+          payload: {
+            app_type: "editor",
+            bundle_id: "com.microsoft.VSCode",
+            is_on_primary_screen: true,
+            covers_editor: false,
+          },
+        });
+      });
+
+      expect(appWindow.setMaxSize).not.toHaveBeenCalled();
+      expect(appWindow.setSize).not.toHaveBeenCalled();
+      expect(appWindow.setPosition).toHaveBeenCalledOnce();
+    });
+
+    it("does not apply a delayed editor resize after the add menu opens", async () => {
+      const { result, listeners, params } = setup({ "onboarding:completed": true });
+
+      await waitFor(() => {
+        expect(result.current.onboardingCompleted).toBe(true);
+        expect(listeners.has("app-activated")).toBe(true);
+        expect(params.fetchWindowsRef.current).toHaveBeenCalled();
+      });
+
+      const appWindow = getCurrentWindow();
+      vi.mocked(appWindow.setMaxSize).mockClear();
+      vi.mocked(appWindow.setSize).mockClear();
+      const handler = listeners.get("app-activated") as unknown as (
+        event: { payload: AppActivationPayload },
+      ) => Promise<void>;
+
+      const activation = handler({
+        payload: {
+          app_type: "editor",
+          bundle_id: "com.microsoft.VSCode",
+          is_on_primary_screen: true,
+          covers_editor: false,
+        },
+      });
+      await act(async () => {
+        await result.current.handleAddMenuOpen();
+        await activation;
+      });
+
+      expect(appWindow.setSize).not.toHaveBeenCalledWith(new LogicalSize(1920, 36));
     });
 
     it("does not resize the window when the tab manager becomes active", async () => {

--- a/src/hooks/useAppLifecycle.ts
+++ b/src/hooks/useAppLifecycle.ts
@@ -33,6 +33,8 @@ interface UseAppLifecycleReturn {
   handleColorPickerClose: () => Promise<void>;
   handleAddMenuOpen: () => Promise<void>;
   handleAddMenuClose: () => Promise<void>;
+  handleEditorPickerOpen: () => Promise<void>;
+  handleEditorPickerClose: () => Promise<void>;
   handleTabContextMenuOpen: () => Promise<void>;
   handleTabContextMenuClose: () => Promise<void>;
   handleWorktreeMenuOpen: (rowCount: number) => Promise<void>;
@@ -305,9 +307,14 @@ export function useAppLifecycle({
   const COLOR_PICKER_HEIGHT = 50;
   const CONTEXT_MENU_HEIGHT = 200;
   const ADD_MENU_HEIGHT = 420;
+  const EDITOR_PICKER_HEIGHT = 420;
 
   const handleColorPickerOpen = useCallback(() => expandWindow(COLOR_PICKER_HEIGHT), [expandWindow]);
   const handleTabContextMenuOpen = useCallback(() => expandWindow(CONTEXT_MENU_HEIGHT), [expandWindow]);
+  const handleEditorPickerOpen = useCallback(
+    () => expandWindow(EDITOR_PICKER_HEIGHT),
+    [expandWindow],
+  );
   const handleWorktreeMenuOpen = useCallback(
     (rowCount: number) => expandWindow(Math.min(420, rowCount * 32 + 8)),
     [expandWindow],
@@ -342,6 +349,7 @@ export function useAppLifecycle({
       await appWindow.show();
       isVisibleRef.current = true;
       isInitializedRef.current = true;
+      await fetchWindowsRef.current();
       await syncActiveTabRef.current();
     };
     initWindow();
@@ -453,6 +461,8 @@ export function useAppLifecycle({
     handleColorPickerClose: handleOverlayClose,
     handleAddMenuOpen,
     handleAddMenuClose,
+    handleEditorPickerOpen,
+    handleEditorPickerClose: handleOverlayClose,
     handleTabContextMenuOpen,
     handleTabContextMenuClose: handleOverlayClose,
     handleWorktreeMenuOpen,

--- a/src/hooks/useAppLifecycle.ts
+++ b/src/hooks/useAppLifecycle.ts
@@ -33,6 +33,7 @@ interface UseAppLifecycleReturn {
   handleColorPickerClose: () => Promise<void>;
   handleAddMenuOpen: () => Promise<void>;
   handleAddMenuClose: () => Promise<void>;
+  handleAddMenuHandoff: () => void;
   handleEditorPickerOpen: () => Promise<void>;
   handleEditorPickerClose: () => Promise<void>;
   handleTabContextMenuOpen: () => Promise<void>;
@@ -70,6 +71,7 @@ export function useAppLifecycle({
   const [tabLayout, setTabLayout] = useState<TabLayout>("horizontal");
   const isInitializedRef = useRef(false);
   const lastMonitorKeyRef = useRef<string | null>(null);
+  const editorPickerOpenRef = useRef(false);
 
   // Load notification + showBranch + language settings from store
   useEffect(() => {
@@ -284,12 +286,23 @@ export function useAppLifecycle({
     const appWindow = getCurrentWindow();
     const monitor = (await currentMonitor()) ?? (await primaryMonitor());
     if (!monitor) return;
+    if (showAddMenuRef.current || editorPickerOpenRef.current) return;
     const screenWidth = monitor.size.width / monitor.scaleFactor;
     const originX = monitor.position.x / monitor.scaleFactor;
     const originY = monitor.position.y / monitor.scaleFactor;
     lastMonitorKeyRef.current = getMonitorKey(monitor);
     await appWindow.setMaxSize(new LogicalSize(screenWidth, TAB_BAR_HEIGHT));
     await appWindow.setSize(new LogicalSize(screenWidth, TAB_BAR_HEIGHT));
+    await appWindow.setPosition(new LogicalPosition(originX, originY));
+  }, [showAddMenuRef]);
+
+  const positionTabBar = useCallback(async () => {
+    const appWindow = getCurrentWindow();
+    const monitor = (await currentMonitor()) ?? (await primaryMonitor());
+    if (!monitor) return;
+    const originX = monitor.position.x / monitor.scaleFactor;
+    const originY = monitor.position.y / monitor.scaleFactor;
+    lastMonitorKeyRef.current = getMonitorKey(monitor);
     await appWindow.setPosition(new LogicalPosition(originX, originY));
   }, []);
 
@@ -311,10 +324,16 @@ export function useAppLifecycle({
 
   const handleColorPickerOpen = useCallback(() => expandWindow(COLOR_PICKER_HEIGHT), [expandWindow]);
   const handleTabContextMenuOpen = useCallback(() => expandWindow(CONTEXT_MENU_HEIGHT), [expandWindow]);
-  const handleEditorPickerOpen = useCallback(
-    () => expandWindow(EDITOR_PICKER_HEIGHT),
-    [expandWindow],
-  );
+  const handleEditorPickerOpen = useCallback(async () => {
+    editorPickerOpenRef.current = true;
+    try {
+      await expandWindow(EDITOR_PICKER_HEIGHT);
+    } catch (error) {
+      editorPickerOpenRef.current = false;
+      await resizeTabBar().catch(() => {});
+      throw error;
+    }
+  }, [expandWindow, resizeTabBar]);
   const handleWorktreeMenuOpen = useCallback(
     (rowCount: number) => expandWindow(Math.min(420, rowCount * 32 + 8)),
     [expandWindow],
@@ -322,17 +341,35 @@ export function useAppLifecycle({
   const handleOverlayClose = useCallback(async () => { await resizeTabBar(); }, [resizeTabBar]);
 
   const handleAddMenuOpen = useCallback(async () => {
-    await expandWindow(ADD_MENU_HEIGHT);
-    setShowAddMenu(true);
-  }, [expandWindow, setShowAddMenu]);
+    showAddMenuRef.current = true;
+    try {
+      await expandWindow(ADD_MENU_HEIGHT);
+      setShowAddMenu(true);
+    } catch (error) {
+      showAddMenuRef.current = false;
+      throw error;
+    }
+  }, [expandWindow, setShowAddMenu, showAddMenuRef]);
 
   const handleAddMenuClose = useCallback(
     async () => {
+      showAddMenuRef.current = false;
       setShowAddMenu(false);
       await resizeTabBar();
     },
-    [resizeTabBar, setShowAddMenu]
+    [resizeTabBar, setShowAddMenu, showAddMenuRef]
   );
+
+  const handleAddMenuHandoff = useCallback(() => {
+    editorPickerOpenRef.current = true;
+    showAddMenuRef.current = false;
+    setShowAddMenu(false);
+  }, [setShowAddMenu, showAddMenuRef]);
+
+  const handleEditorPickerClose = useCallback(async () => {
+    editorPickerOpenRef.current = false;
+    await resizeTabBar();
+  }, [resizeTabBar]);
 
   // Event-driven visibility (no polling)
   useEffect(() => {
@@ -370,7 +407,11 @@ export function useAppLifecycle({
           if (app_type === "editor") {
             // Wait 150ms for macOS window animation to complete
             await new Promise((resolve) => setTimeout(resolve, 150));
-            await resizeTabBar();
+            if (showAddMenuRef.current || editorPickerOpenRef.current) {
+              await positionTabBar();
+            } else {
+              await resizeTabBar();
+            }
           }
           isVisibleRef.current = true;
           if (app_type === "editor") {
@@ -410,6 +451,7 @@ export function useAppLifecycle({
       const unlisten = await listen("display-changed", async () => {
         if (!isMounted) return;
         if (showAddMenuRef.current) return;
+        if (editorPickerOpenRef.current) return;
         if (!isVisibleRef.current) return;
         await resizeTabBar();
       });
@@ -421,6 +463,7 @@ export function useAppLifecycle({
       const unlisten = await appWindow.onMoved(async () => {
         if (!isMounted) return;
         if (showAddMenuRef.current) return;
+        if (editorPickerOpenRef.current) return;
         if (!isVisibleRef.current) return;
         const monitor = (await currentMonitor()) ?? (await primaryMonitor());
         if (!monitor) return;
@@ -438,6 +481,7 @@ export function useAppLifecycle({
     };
   }, [
     resizeTabBar,
+    positionTabBar,
     hasAccessibilityPermission,
     onboardingCompleted,
     fetchWindowsRef,
@@ -461,8 +505,9 @@ export function useAppLifecycle({
     handleColorPickerClose: handleOverlayClose,
     handleAddMenuOpen,
     handleAddMenuClose,
+    handleAddMenuHandoff,
     handleEditorPickerOpen,
-    handleEditorPickerClose: handleOverlayClose,
+    handleEditorPickerClose,
     handleTabContextMenuOpen,
     handleTabContextMenuClose: handleOverlayClose,
     handleWorktreeMenuOpen,

--- a/src/hooks/useClaudeStatus.ts
+++ b/src/hooks/useClaudeStatus.ts
@@ -140,11 +140,14 @@ export function useClaudeStatus({
 
         await new Promise((r) => setTimeout(r, 500));
 
-        const win = windowsRef.current.find((w) => projectPathMatchesWindow(projectPath, w));
+        const win = windowsRef.current.find(
+          (w) => w.is_open !== false && projectPathMatchesWindow(projectPath, w),
+        );
         if (win) {
           await invoke("focus_editor_window", { bundle_id: win.bundle_id, window_id: win.id });
-        } else if (windowsRef.current.length > 0) {
-          const first = windowsRef.current[0];
+        } else {
+          const first = windowsRef.current.find((window) => window.is_open !== false);
+          if (!first) return;
           await invoke("focus_editor_window", { bundle_id: first.bundle_id, window_id: first.id });
         }
       });

--- a/src/hooks/useEditorWindows.test.ts
+++ b/src/hooks/useEditorWindows.test.ts
@@ -1,14 +1,17 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import type { EditorWindow, GroupAssignment, GroupDefinition, TabColorMap, WindowsSnapshot } from "../types/editor";
+import type { EditorWindow, GroupAssignment, GroupDefinition, HistoryEntry, SavedTab, TabColorMap, WindowsSnapshot } from "../types/editor";
 import { useEditorWindows } from "./useEditorWindows";
 
 // Mock store functions directly
 const mockLoadTabOrder = vi.fn<() => Promise<string[]>>().mockResolvedValue([]);
 const mockLoadTabColors = vi.fn<() => Promise<TabColorMap>>().mockResolvedValue({});
+const mockLoadSavedTabs = vi.fn<() => Promise<SavedTab[]>>().mockResolvedValue([]);
+const mockLoadHistory = vi.fn<() => Promise<HistoryEntry[]>>().mockResolvedValue([]);
 const mockSaveTabOrder = vi.fn().mockResolvedValue(undefined);
 const mockSaveTabColors = vi.fn().mockResolvedValue(undefined);
+const mockSaveSavedTabs = vi.fn().mockResolvedValue(undefined);
 const mockLoadGroups = vi.fn<() => Promise<GroupDefinition[]>>().mockResolvedValue([]);
 const mockSaveGroups = vi.fn().mockResolvedValue(undefined);
 const mockLoadGroupAssignments = vi.fn<() => Promise<GroupAssignment>>().mockResolvedValue({});
@@ -27,8 +30,11 @@ const mockMigrateResolvedWindowKeys = vi.fn(
 vi.mock("../utils/store", () => ({
   loadTabOrder: (...args: unknown[]) => mockLoadTabOrder(...(args as [])),
   loadTabColors: (...args: unknown[]) => mockLoadTabColors(...(args as [])),
+  loadSavedTabs: (...args: unknown[]) => mockLoadSavedTabs(...(args as [])),
+  loadHistory: (...args: unknown[]) => mockLoadHistory(...(args as [])),
   saveTabOrder: (...args: unknown[]) => mockSaveTabOrder(...(args as [string[]])),
   saveTabColors: (...args: unknown[]) => mockSaveTabColors(...(args as [TabColorMap])),
+  saveSavedTabs: (...args: unknown[]) => mockSaveSavedTabs(...(args as [SavedTab[]])),
   loadGroups: (...args: unknown[]) => mockLoadGroups(...(args as [])),
   saveGroups: (...args: unknown[]) => mockSaveGroups(...args),
   loadGroupAssignments: (...args: unknown[]) => mockLoadGroupAssignments(...(args as [])),
@@ -37,6 +43,8 @@ vi.mock("../utils/store", () => ({
   saveCollapsedGroups: (...args: unknown[]) => mockSaveCollapsedGroups(...args),
   loadGroupColors: (...args: unknown[]) => mockLoadGroupColors(...(args as [])),
   saveGroupColors: (...args: unknown[]) => mockSaveGroupColors(...args),
+  normalizeProjectPath: (path: string) => path.length > 1 ? path.replace(/\/+$/, "") : path,
+  legacyWindowKey: (w: EditorWindow) => `${w.bundle_id}:${w.name}`,
   windowKey: (w: EditorWindow) => mockWindowKey(w),
   runtimeWindowKey: (w: EditorWindow) => mockRuntimeWindowKey(w),
   migrateResolvedWindowKeys: (order: string[], current: EditorWindow[], next: EditorWindow[]) =>
@@ -45,10 +53,11 @@ vi.mock("../utils/store", () => ({
 }));
 
 function makeWindow(overrides: Partial<EditorWindow> = {}): EditorWindow {
+  const name = overrides.name ?? "my-project";
   return {
     id: 1,
-    name: "my-project",
-    path: "/Users/test/my-project",
+    name,
+    path: overrides.path ?? `/Users/test/${name}`,
     bundle_id: "com.microsoft.VSCode",
     editor_name: "VSCode",
     ...overrides,
@@ -88,8 +97,11 @@ describe("useEditorWindows", () => {
     vi.mocked(listen).mockClear();
     mockLoadTabOrder.mockClear().mockResolvedValue([]);
     mockLoadTabColors.mockClear().mockResolvedValue({});
+    mockLoadSavedTabs.mockClear().mockResolvedValue([]);
+    mockLoadHistory.mockClear().mockResolvedValue([]);
     mockSaveTabOrder.mockClear().mockResolvedValue(undefined);
     mockSaveTabColors.mockClear().mockResolvedValue(undefined);
+    mockSaveSavedTabs.mockClear().mockResolvedValue(undefined);
     mockLoadGroups.mockClear().mockResolvedValue([]);
     mockSaveGroups.mockClear().mockResolvedValue(undefined);
     mockLoadGroupAssignments.mockClear().mockResolvedValue({});
@@ -110,6 +122,19 @@ describe("useEditorWindows", () => {
     expect(result.current.windows).toEqual([]);
     expect(result.current.activeIndex).toBe(0);
     expect(result.current.tabColors).toEqual({});
+  });
+
+  it("opens a new window with the editor selected in the add menu", async () => {
+    vi.mocked(invoke).mockResolvedValue(undefined);
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.handleNewTab("com.todesktop.230313mzl4w4u92");
+    });
+
+    expect(invoke).toHaveBeenCalledWith("open_new_editor", {
+      bundle_id: "com.todesktop.230313mzl4w4u92",
+    });
   });
 
   describe("fetchWindows", () => {
@@ -143,6 +168,61 @@ describe("useEditorWindows", () => {
 
       // loadTabOrder should only be called once (cached)
       expect(mockLoadTabOrder).toHaveBeenCalledOnce();
+    });
+
+    it("restores saved tabs when no editor window is open", async () => {
+      mockLoadSavedTabs.mockResolvedValue([{
+        name: "saved-project",
+        path: "/projects/saved-project",
+        bundle_id: "com.microsoft.VSCode",
+        editor_name: "VSCode",
+      }]);
+      vi.mocked(invoke).mockResolvedValue([]);
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.fetchWindows();
+      });
+
+      expect(result.current.windows).toEqual([
+        expect.objectContaining({
+          name: "saved-project",
+          path: "/projects/saved-project",
+          is_open: false,
+        }),
+      ]);
+    });
+
+    it("migrates the previous tab order when saved tabs have not been created yet", async () => {
+      mockLoadTabOrder.mockResolvedValue([
+        "com.microsoft.VSCode:/projects/legacy-project",
+      ]);
+      mockLoadHistory.mockResolvedValue([{
+        name: "legacy-project",
+        path: "/projects/legacy-project",
+        bundleId: "com.microsoft.VSCode",
+        editorName: "VSCode",
+        timestamp: 1,
+      }]);
+      vi.mocked(invoke).mockResolvedValue([]);
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.fetchWindows();
+      });
+
+      expect(result.current.windows).toEqual([
+        expect.objectContaining({
+          name: "legacy-project",
+          is_open: false,
+        }),
+      ]);
+      expect(mockSaveSavedTabs).toHaveBeenCalledWith([
+        expect.objectContaining({
+          path: "/projects/legacy-project",
+          bundle_id: "com.microsoft.VSCode",
+        }),
+      ]);
     });
 
     it("adjusts activeIndex when it exceeds window count", async () => {
@@ -209,6 +289,29 @@ describe("useEditorWindows", () => {
       expect(params.addToHistory).toHaveBeenCalledWith(
         expect.arrayContaining([expect.objectContaining({ name: "beta" })])
       );
+    });
+
+    it("keeps a tab after its editor window closes", async () => {
+      const win = makeWindow({ id: 1, name: "alpha", path: "/path/alpha" });
+      vi.mocked(invoke).mockResolvedValue([win]);
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.refreshWindows();
+      });
+
+      vi.mocked(invoke).mockResolvedValue([]);
+      await act(async () => {
+        await result.current.refreshWindows();
+      });
+
+      expect(result.current.windows).toEqual([
+        expect.objectContaining({
+          name: "alpha",
+          path: "/path/alpha",
+          is_open: false,
+        }),
+      ]);
     });
 
     it("updates a same-named window when its worktree path changes", async () => {
@@ -388,7 +491,9 @@ describe("useEditorWindows", () => {
       });
 
       expect(result.current.activeIndex).toBe(1);
-      expect(params.dismissWaitingForWindow).toHaveBeenCalledWith(win2);
+      expect(params.dismissWaitingForWindow).toHaveBeenCalledWith(
+        expect.objectContaining(win2),
+      );
       expect(invoke).toHaveBeenCalledWith("focus_editor_window", {
         bundle_id: win2.bundle_id,
         window_id: win2.id,
@@ -412,6 +517,196 @@ describe("useEditorWindows", () => {
 
       expect(invoke).not.toHaveBeenCalledWith("focus_editor_window", expect.anything());
       expect(params.dismissWaitingForWindow).not.toHaveBeenCalled();
+    });
+
+    it("reopens a saved tab in the selected editor", async () => {
+      mockLoadSavedTabs.mockResolvedValue([{
+        name: "saved-project",
+        path: "/projects/saved-project",
+        bundle_id: "com.microsoft.VSCode",
+        editor_name: "VSCode",
+      }]);
+      vi.mocked(invoke).mockResolvedValue([]);
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.fetchWindows();
+      });
+
+      vi.mocked(invoke).mockClear();
+      vi.mocked(invoke).mockResolvedValue(undefined);
+      await act(async () => {
+        await result.current.handleOpenSavedTab(0, "com.todesktop.230313mzl4w4u92");
+      });
+
+      expect(invoke).toHaveBeenCalledWith("open_project_in_editor", {
+        bundle_id: "com.todesktop.230313mzl4w4u92",
+        path: "/projects/saved-project",
+      });
+      expect(mockSaveSavedTabs).toHaveBeenCalledWith([
+        expect.objectContaining({
+          path: "/projects/saved-project",
+          bundle_id: "com.todesktop.230313mzl4w4u92",
+        }),
+      ]);
+    });
+
+    it("preserves the group when reopening a saved tab in another editor", async () => {
+      const sourceKey = "com.microsoft.VSCode:/projects/saved-project";
+      const targetKey = "com.todesktop.230313mzl4w4u92:/projects/saved-project";
+      mockLoadSavedTabs.mockResolvedValue([{
+        name: "saved-project",
+        path: "/projects/saved-project",
+        bundle_id: "com.microsoft.VSCode",
+        editor_name: "VSCode",
+      }]);
+      mockLoadGroupAssignments.mockResolvedValue({
+        [sourceKey]: "group-1",
+      });
+      vi.mocked(invoke).mockResolvedValue([]);
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.fetchWindows();
+      });
+
+      vi.mocked(invoke).mockResolvedValue(undefined);
+      await act(async () => {
+        await result.current.handleOpenSavedTab(0, "com.todesktop.230313mzl4w4u92");
+      });
+
+      expect(result.current.groupAssignments).toEqual({
+        [targetKey]: "group-1",
+      });
+      expect(mockSaveGroupAssignments).toHaveBeenCalledWith({
+        [targetKey]: "group-1",
+      });
+    });
+
+    it("uses the displayed group when reopening an inherited grouped tab", async () => {
+      const targetKey = "dev.zed.Zed:/projects/saved-project";
+      mockLoadSavedTabs.mockResolvedValue([{
+        name: "saved-project",
+        path: "/projects/saved-project",
+        bundle_id: "com.microsoft.VSCode",
+        editor_name: "VSCode",
+      }]);
+      vi.mocked(invoke).mockResolvedValue([]);
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.fetchWindows();
+      });
+
+      vi.mocked(invoke).mockResolvedValue(undefined);
+      await act(async () => {
+        await result.current.handleOpenSavedTab(0, "dev.zed.Zed", "group-1");
+      });
+
+      expect(result.current.groupAssignments).toEqual({
+        [targetKey]: "group-1",
+      });
+      expect(mockSaveGroupAssignments).toHaveBeenCalledWith({
+        [targetKey]: "group-1",
+      });
+    });
+
+    it("marks a saved tab when reopening it fails", async () => {
+      mockLoadSavedTabs.mockResolvedValue([{
+        name: "saved-project",
+        path: "/projects/saved-project",
+        bundle_id: "com.microsoft.VSCode",
+        editor_name: "VSCode",
+      }]);
+      vi.mocked(invoke).mockResolvedValue([]);
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.fetchWindows();
+      });
+
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      vi.mocked(invoke).mockRejectedValue(new Error("open failed"));
+      await act(async () => {
+        await result.current.handleOpenSavedTab(0, "dev.zed.Zed");
+      });
+
+      expect(result.current.windows[0].open_error).toBe(true);
+      expect(result.current.windows[0].bundle_id).toBe("dev.zed.Zed");
+      consoleError.mockRestore();
+    });
+
+    it("does not reopen a saved tab until an editor is selected", async () => {
+      mockLoadSavedTabs.mockResolvedValue([{
+        name: "saved-project",
+        path: "/projects/saved-project",
+        bundle_id: "com.microsoft.VSCode",
+        editor_name: "VSCode",
+      }]);
+      vi.mocked(invoke).mockResolvedValue([]);
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.fetchWindows();
+      });
+
+      vi.mocked(invoke).mockClear();
+      act(() => {
+        result.current.handleTabClick(0);
+      });
+
+      expect(invoke).not.toHaveBeenCalledWith("open_project_in_editor", expect.anything());
+    });
+
+    it("focuses an existing selected-editor window and merges the closed duplicate", async () => {
+      const path = "/projects/shared-project";
+      mockLoadSavedTabs.mockResolvedValue([
+        {
+          name: "shared-project",
+          path,
+          bundle_id: "com.microsoft.VSCode",
+          editor_name: "VSCode",
+        },
+        {
+          name: "shared-project",
+          path,
+          bundle_id: "com.todesktop.230313mzl4w4u92",
+          editor_name: "Cursor",
+        },
+      ]);
+      const cursorWindow = makeWindow({
+        id: 2,
+        name: "shared-project",
+        path,
+        bundle_id: "com.todesktop.230313mzl4w4u92",
+        editor_name: "Cursor",
+      });
+      vi.mocked(invoke).mockResolvedValue([cursorWindow]);
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.fetchWindows();
+      });
+
+      const closedIndex = result.current.windows.findIndex(
+        (window) => window.bundle_id === "com.microsoft.VSCode",
+      );
+      vi.mocked(invoke).mockClear();
+      vi.mocked(invoke).mockResolvedValue(undefined);
+
+      await act(async () => {
+        await result.current.handleOpenSavedTab(
+          closedIndex,
+          "com.todesktop.230313mzl4w4u92",
+        );
+      });
+
+      expect(invoke).toHaveBeenCalledWith("focus_editor_window", {
+        bundle_id: "com.todesktop.230313mzl4w4u92",
+        window_id: 2,
+      });
+      expect(invoke).not.toHaveBeenCalledWith("open_project_in_editor", expect.anything());
+      expect(result.current.windows).toHaveLength(1);
     });
   });
 
@@ -466,6 +761,7 @@ describe("useEditorWindows", () => {
       await act(async () => {
         await result.current.refreshWindows();
       });
+      mockSaveTabOrder.mockClear();
 
       act(() => {
         result.current.handleReorder(-1, 0);

--- a/src/hooks/useEditorWindows.test.ts
+++ b/src/hooks/useEditorWindows.test.ts
@@ -20,7 +20,8 @@ const mockLoadCollapsedGroups = vi.fn<() => Promise<string[]>>().mockResolvedVal
 const mockSaveCollapsedGroups = vi.fn().mockResolvedValue(undefined);
 const mockLoadGroupColors = vi.fn<() => Promise<Record<string, string>>>().mockResolvedValue({});
 const mockSaveGroupColors = vi.fn().mockResolvedValue(undefined);
-const mockWindowKey = vi.fn((w: EditorWindow) => `${w.bundle_id}:${w.path || w.name}`);
+const defaultWindowKey = (w: EditorWindow) => `${w.bundle_id}:${w.path || w.name}`;
+const mockWindowKey = vi.fn(defaultWindowKey);
 const mockRuntimeWindowKey = vi.fn((w: EditorWindow) => w.runtime_id ?? `${w.bundle_id}:${w.id}`);
 const mockSortWindowsByOrder = vi.fn((windows: EditorWindow[], _order: string[]) => [...windows]);
 const mockMigrateResolvedWindowKeys = vi.fn(
@@ -66,6 +67,16 @@ function makeWindow(overrides: Partial<EditorWindow> = {}): EditorWindow {
 
 type ListenHandler = (event: { payload: unknown }) => void;
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 function setup() {
   const listeners = new Map<string, ListenHandler>();
   vi.mocked(listen).mockImplementation(async (event: string, handler: unknown) => {
@@ -110,6 +121,7 @@ describe("useEditorWindows", () => {
     mockSaveCollapsedGroups.mockClear().mockResolvedValue(undefined);
     mockLoadGroupColors.mockClear().mockResolvedValue({});
     mockSaveGroupColors.mockClear().mockResolvedValue(undefined);
+    mockWindowKey.mockClear().mockImplementation(defaultWindowKey);
     mockSortWindowsByOrder.mockClear().mockImplementation((windows) => [...windows]);
     mockRuntimeWindowKey.mockClear().mockImplementation(
       (window) => window.runtime_id ?? `${window.bundle_id}:${window.id}`,
@@ -237,6 +249,105 @@ describe("useEditorWindows", () => {
       ]);
     });
 
+    it("refreshes stored Git metadata even when every field already exists", async () => {
+      mockLoadSavedTabs.mockResolvedValue([{
+        name: "saved-project",
+        path: "/worktrees/feature/saved-project",
+        branch: "feature/old",
+        repository_id: "/projects/old/.git",
+        repository_name: "old",
+        bundle_id: "dev.zed.Zed",
+        editor_name: "Zed",
+      }]);
+      vi.mocked(invoke).mockImplementation(async (command) => {
+        if (command === "get_project_metadata") {
+          return [{
+            path: "/worktrees/feature/saved-project",
+            branch: "feature/current",
+            repository_id: "/projects/saved-project/.git",
+            repository_name: "saved-project",
+          }];
+        }
+        return [];
+      });
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.fetchWindows();
+      });
+
+      expect(invoke).toHaveBeenCalledWith("get_project_metadata", {
+        paths: ["/worktrees/feature/saved-project"],
+      });
+      expect(result.current.windows).toEqual([
+        expect.objectContaining({
+          branch: "feature/current",
+          repository_id: "/projects/saved-project/.git",
+          repository_name: "saved-project",
+          is_open: false,
+        }),
+      ]);
+      expect(mockSaveSavedTabs).toHaveBeenCalledWith([
+        expect.objectContaining({
+          branch: "feature/current",
+          repository_id: "/projects/saved-project/.git",
+          repository_name: "saved-project",
+        }),
+      ]);
+    });
+
+    it("shows saved tabs before the initial window snapshot succeeds", async () => {
+      const pendingSnapshot = deferred<WindowsSnapshot>();
+      mockLoadSavedTabs.mockResolvedValue([{
+        name: "saved-project",
+        path: "/projects/saved-project",
+        bundle_id: "com.microsoft.VSCode",
+        editor_name: "VSCode",
+      }]);
+      vi.mocked(invoke).mockImplementation((command) => {
+        if (command === "get_project_metadata") {
+          return Promise.resolve([{
+            path: "/projects/saved-project",
+            branch: null,
+            repository_id: null,
+            repository_name: null,
+          }]);
+        }
+        if (command === "get_windows_snapshot") {
+          return pendingSnapshot.promise;
+        }
+        return Promise.resolve(undefined);
+      });
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      const { result } = setup();
+      let fetchPromise!: Promise<number>;
+
+      act(() => {
+        fetchPromise = result.current.fetchWindows();
+      });
+
+      await waitFor(() => {
+        expect(result.current.windows).toEqual([
+          expect.objectContaining({
+            path: "/projects/saved-project",
+            is_open: false,
+          }),
+        ]);
+      });
+
+      pendingSnapshot.reject(new Error("snapshot failed"));
+      await act(async () => {
+        await fetchPromise;
+      });
+      expect(result.current.windows[0]).toEqual(
+        expect.objectContaining({
+          path: "/projects/saved-project",
+          is_open: false,
+        }),
+      );
+      consoleError.mockRestore();
+    });
+
     it("migrates the previous tab order when saved tabs have not been created yet", async () => {
       mockLoadTabOrder.mockResolvedValue([
         "com.microsoft.VSCode:/projects/legacy-project",
@@ -266,6 +377,114 @@ describe("useEditorWindows", () => {
           path: "/projects/legacy-project",
           bundle_id: "com.microsoft.VSCode",
         }),
+      ]);
+    });
+
+    it("recovers a legacy name-based order from a unique history entry", async () => {
+      mockLoadTabOrder.mockResolvedValue([
+        "com.microsoft.VSCode:legacy-project",
+      ]);
+      mockLoadHistory.mockResolvedValue([{
+        name: "legacy-project",
+        path: "/projects/legacy-project",
+        bundleId: "com.microsoft.VSCode",
+        editorName: "VSCode",
+        timestamp: 1,
+      }]);
+      vi.mocked(invoke).mockResolvedValue([]);
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.fetchWindows();
+      });
+
+      expect(result.current.windows).toEqual([
+        expect.objectContaining({
+          path: "/projects/legacy-project",
+          is_open: false,
+        }),
+      ]);
+      expect(mockSaveTabOrder).toHaveBeenCalledWith([
+        "com.microsoft.VSCode:/projects/legacy-project",
+      ]);
+    });
+
+    it("recovers missing path-based order entries when saved tabs already exist", async () => {
+      mockLoadTabOrder.mockResolvedValue([
+        "com.microsoft.VSCode:/projects/saved-project",
+        "dev.zed.Zed:/projects/legacy-project",
+      ]);
+      mockLoadSavedTabs.mockResolvedValue([{
+        name: "saved-project",
+        path: "/projects/saved-project",
+        bundle_id: "com.microsoft.VSCode",
+        editor_name: "VSCode",
+      }]);
+      vi.mocked(invoke).mockResolvedValue([]);
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.fetchWindows();
+      });
+
+      expect(result.current.windows).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ path: "/projects/saved-project" }),
+          expect.objectContaining({ path: "/projects/legacy-project" }),
+        ]),
+      );
+      expect(mockSaveSavedTabs).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: "/projects/legacy-project",
+            bundle_id: "dev.zed.Zed",
+          }),
+        ]),
+      );
+    });
+
+    it("does not erase an unresolved legacy name-based order", async () => {
+      mockLoadTabOrder.mockResolvedValue([
+        "dev.zed.Zed:ambiguous-project",
+      ]);
+      vi.mocked(invoke).mockResolvedValue([]);
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.fetchWindows();
+      });
+
+      expect(mockSaveTabOrder).not.toHaveBeenCalledWith([]);
+      expect(mockSaveTabOrder).not.toHaveBeenCalled();
+    });
+
+    it("does not replace a legacy name order with an unresolved runtime key", async () => {
+      const legacyKey = "dev.zed.Zed:ambiguous-project";
+      const unresolved = makeWindow({
+        id: 42,
+        runtime_id: "dev.zed.Zed:100:42",
+        name: "ambiguous-project",
+        path: "",
+        bundle_id: "dev.zed.Zed",
+        editor_name: "Zed",
+        resolution: "unresolved",
+      });
+      mockWindowKey.mockImplementation((window) =>
+        window.path
+          ? `${window.bundle_id}:${window.path}`
+          : `${window.bundle_id}:runtime:${mockRuntimeWindowKey(window)}`
+      );
+      mockLoadTabOrder.mockResolvedValue([legacyKey]);
+      vi.mocked(invoke).mockResolvedValue([unresolved]);
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.fetchWindows();
+      });
+
+      expect(mockSaveTabOrder).toHaveBeenCalledWith([
+        legacyKey,
+        "dev.zed.Zed:runtime:dev.zed.Zed:100:42",
       ]);
     });
 
@@ -451,21 +670,114 @@ describe("useEditorWindows", () => {
 
       expect(mockSaveTabOrder).toHaveBeenCalledWith(["resolved-order-key"]);
     });
+
+    it.each(["refreshWindows", "fetchWindows"] as const)(
+      "ignores a stale %s response after a newer snapshot event",
+      async (method) => {
+        const initial = makeWindow({ id: 1, name: "initial" });
+        const stale = makeWindow({ id: 2, name: "stale" });
+        const current = makeWindow({ id: 3, name: "current" });
+        const pendingSnapshot = deferred<WindowsSnapshot>();
+        let snapshotCallCount = 0;
+        vi.mocked(invoke).mockImplementation((command) => {
+          if (command !== "get_windows_snapshot") {
+            return Promise.resolve(undefined);
+          }
+          snapshotCallCount += 1;
+          if (snapshotCallCount === 1) {
+            return Promise.resolve({
+              revision: 1,
+              windows: [initial],
+              active_id: initial.id,
+              source: "test",
+            });
+          }
+          return pendingSnapshot.promise;
+        });
+        const { result, listeners } = setup();
+
+        await act(async () => {
+          await result.current.fetchWindows();
+        });
+        await waitFor(() => expect(listeners.has("windows:snapshot")).toBe(true));
+
+        let requestPromise!: Promise<void> | Promise<number>;
+        act(() => {
+          requestPromise = result.current[method]();
+        });
+        await waitFor(() => expect(snapshotCallCount).toBe(2));
+
+        act(() => {
+          listeners.get("windows:snapshot")!({
+            payload: {
+              revision: 3,
+              windows: [current],
+              active_id: current.id,
+              source: "test",
+            },
+          });
+        });
+        pendingSnapshot.resolve({
+          revision: 2,
+          windows: [stale],
+          active_id: stale.id,
+          source: "test",
+        });
+        await act(async () => {
+          await requestPromise;
+        });
+
+        expect(result.current.windows).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ name: "current", is_open: true }),
+            expect.objectContaining({ name: "initial", is_open: false }),
+          ]),
+        );
+        expect(result.current.windows).not.toEqual(
+          expect.arrayContaining([expect.objectContaining({ name: "stale" })]),
+        );
+      },
+    );
+
+    it("does not reapply an already handled structured snapshot revision", async () => {
+      const win1 = makeWindow({ id: 1, name: "alpha" });
+      const win2 = makeWindow({ id: 2, name: "beta" });
+      const snapshot: WindowsSnapshot = {
+        revision: 5,
+        windows: [win1, win2],
+        active_id: win1.id,
+        source: "test",
+      };
+      vi.mocked(invoke).mockImplementation((command) => {
+        if (command === "get_windows_snapshot") {
+          return Promise.resolve(snapshot);
+        }
+        return Promise.resolve(undefined);
+      });
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.fetchWindows();
+      });
+      act(() => {
+        result.current.handleReorder(0, 1);
+      });
+
+      await act(async () => {
+        await result.current.fetchWindows();
+      });
+
+      expect(result.current.windows.map((window) => window.name)).toEqual([
+        "beta",
+        "alpha",
+      ]);
+    });
   });
 
   describe("syncActiveTab", () => {
     it("syncs active tab with frontmost window", async () => {
       const win1 = makeWindow({ id: 1, name: "alpha" });
       const win2 = makeWindow({ id: 2, name: "beta" });
-
-      // Setup: first fetch windows
-      vi.mocked(invoke).mockResolvedValue([win1, win2]);
-      const { result, params } = setup();
-
-      await act(async () => {
-        await result.current.refreshWindows();
-      });
-
       const snapshot: WindowsSnapshot = {
         revision: 1,
         windows: [win1, win2],
@@ -473,6 +785,12 @@ describe("useEditorWindows", () => {
         source: "test",
       };
       vi.mocked(invoke).mockResolvedValue(snapshot);
+      const { result, params } = setup();
+
+      await act(async () => {
+        await result.current.refreshWindows();
+      });
+      expect(result.current.activeIndex).toBe(0);
 
       await act(async () => {
         await result.current.syncActiveTab();
@@ -513,6 +831,62 @@ describe("useEditorWindows", () => {
       });
 
       // Active index should NOT have changed back to 0
+      expect(result.current.activeIndex).toBe(1);
+    });
+
+    it("ignores a stale active-window snapshot after a newer event", async () => {
+      const win1 = makeWindow({ id: 1, name: "alpha" });
+      const win2 = makeWindow({ id: 2, name: "beta" });
+      const pendingSnapshot = deferred<WindowsSnapshot>();
+      let snapshotCallCount = 0;
+      vi.mocked(invoke).mockImplementation((command) => {
+        if (command !== "get_windows_snapshot") {
+          return Promise.resolve(undefined);
+        }
+        snapshotCallCount += 1;
+        if (snapshotCallCount === 1) {
+          return Promise.resolve({
+            revision: 1,
+            windows: [win1, win2],
+            active_id: win1.id,
+            source: "test",
+          });
+        }
+        return pendingSnapshot.promise;
+      });
+      const { result, listeners } = setup();
+
+      await act(async () => {
+        await result.current.fetchWindows();
+      });
+      await waitFor(() => expect(listeners.has("windows:snapshot")).toBe(true));
+
+      let syncPromise!: Promise<void>;
+      act(() => {
+        syncPromise = result.current.syncActiveTab();
+      });
+      await waitFor(() => expect(snapshotCallCount).toBe(2));
+
+      act(() => {
+        listeners.get("windows:snapshot")!({
+          payload: {
+            revision: 3,
+            windows: [win1, win2],
+            active_id: win2.id,
+            source: "test",
+          },
+        });
+      });
+      pendingSnapshot.resolve({
+        revision: 2,
+        windows: [win1, win2],
+        active_id: win1.id,
+        source: "test",
+      });
+      await act(async () => {
+        await syncPromise;
+      });
+
       expect(result.current.activeIndex).toBe(1);
     });
   });
@@ -775,6 +1149,66 @@ describe("useEditorWindows", () => {
       expect(result.current.windows[1].name).toBe("gamma");
       expect(result.current.windows[2].name).toBe("alpha");
       expect(mockSaveTabOrder).toHaveBeenCalled();
+    });
+
+    it("preserves an unresolved legacy order when reordering tabs", async () => {
+      const legacyKey = "dev.zed.Zed:project";
+      const win1 = makeWindow({
+        id: 1,
+        name: "project",
+        path: "/worktrees/one/project",
+        bundle_id: "dev.zed.Zed",
+        editor_name: "Zed",
+      });
+      const win2 = makeWindow({
+        id: 2,
+        name: "project",
+        path: "/worktrees/two/project",
+        bundle_id: "dev.zed.Zed",
+        editor_name: "Zed",
+      });
+      mockLoadTabOrder.mockResolvedValue([legacyKey]);
+      vi.mocked(invoke).mockResolvedValue([win1, win2]);
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.fetchWindows();
+      });
+      mockSaveTabOrder.mockClear();
+
+      act(() => {
+        result.current.handleReorder(0, 1);
+      });
+
+      expect(mockSaveTabOrder).toHaveBeenCalledWith([
+        legacyKey,
+        defaultWindowKey(win2),
+        defaultWindowKey(win1),
+      ]);
+    });
+
+    it("preserves an unresolved legacy order when applying visual order", async () => {
+      const legacyKey = "dev.zed.Zed:unresolved-project";
+      const win1 = makeWindow({ id: 1, name: "alpha" });
+      const win2 = makeWindow({ id: 2, name: "beta" });
+      mockLoadTabOrder.mockResolvedValue([legacyKey]);
+      vi.mocked(invoke).mockResolvedValue([win1, win2]);
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.fetchWindows();
+      });
+      mockSaveTabOrder.mockClear();
+
+      act(() => {
+        result.current.handleReorderByVisual([1, 0]);
+      });
+
+      expect(mockSaveTabOrder).toHaveBeenCalledWith([
+        legacyKey,
+        defaultWindowKey(win2),
+        defaultWindowKey(win1),
+      ]);
     });
 
     it("updates activeIndex when the active tab is moved", async () => {

--- a/src/hooks/useEditorWindows.test.ts
+++ b/src/hooks/useEditorWindows.test.ts
@@ -193,6 +193,50 @@ describe("useEditorWindows", () => {
       ]);
     });
 
+    it("restores missing Git metadata from a saved tab path", async () => {
+      mockLoadSavedTabs.mockResolvedValue([{
+        name: "saved-project",
+        path: "/worktrees/feature/saved-project",
+        bundle_id: "dev.zed.Zed",
+        editor_name: "Zed",
+      }]);
+      vi.mocked(invoke).mockImplementation(async (command) => {
+        if (command === "get_project_metadata") {
+          return [{
+            path: "/worktrees/feature/saved-project",
+            branch: "feature/saved-tab",
+            repository_id: "/projects/saved-project/.git",
+            repository_name: "saved-project",
+          }];
+        }
+        return [];
+      });
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.fetchWindows();
+      });
+
+      expect(invoke).toHaveBeenCalledWith("get_project_metadata", {
+        paths: ["/worktrees/feature/saved-project"],
+      });
+      expect(result.current.windows).toEqual([
+        expect.objectContaining({
+          branch: "feature/saved-tab",
+          repository_id: "/projects/saved-project/.git",
+          repository_name: "saved-project",
+          is_open: false,
+        }),
+      ]);
+      expect(mockSaveSavedTabs).toHaveBeenCalledWith([
+        expect.objectContaining({
+          branch: "feature/saved-tab",
+          repository_id: "/projects/saved-project/.git",
+          repository_name: "saved-project",
+        }),
+      ]);
+    });
+
     it("migrates the previous tab order when saved tabs have not been created yet", async () => {
       mockLoadTabOrder.mockResolvedValue([
         "com.microsoft.VSCode:/projects/legacy-project",

--- a/src/hooks/useEditorWindows.ts
+++ b/src/hooks/useEditorWindows.ts
@@ -116,6 +116,115 @@ function normalizeSnapshot(payload: WindowsSnapshot | EditorWindow[]): WindowsSn
   return payload;
 }
 
+function isAppliedStructuredSnapshot(
+  payload: WindowsSnapshot | EditorWindow[],
+  lastRevision: number,
+): boolean {
+  return !Array.isArray(payload) && payload.revision <= lastRevision;
+}
+
+function isLegacyNameOrderKey(key: string): boolean {
+  return ALL_EDITOR_BUNDLE_IDS.some((bundleId) => {
+    const prefix = `${bundleId}:`;
+    if (!key.startsWith(prefix)) return false;
+    const identity = key.slice(prefix.length);
+    return Boolean(identity) &&
+      !identity.startsWith("/") &&
+      !identity.startsWith("runtime:");
+  });
+}
+
+function mergeOrderWithUnresolvedLegacyKeys(
+  currentOrder: string[],
+  tabs: EditorWindow[],
+): string[] {
+  const nextKeys = [...new Set(tabs.map(windowKey))];
+  const nextKeySet = new Set(nextKeys);
+  const pathKeysByLegacyKey = new Map<string, Set<string>>();
+  for (const tab of tabs) {
+    if (!tab.path) continue;
+    const key = legacyWindowKey(tab);
+    const pathKeys = pathKeysByLegacyKey.get(key) ?? new Set<string>();
+    pathKeys.add(windowKey(tab));
+    pathKeysByLegacyKey.set(key, pathKeys);
+  }
+
+  const merged: string[] = [];
+  const seen = new Set<string>();
+  const append = (key: string) => {
+    if (seen.has(key)) return;
+    seen.add(key);
+    merged.push(key);
+  };
+
+  for (const key of currentOrder) {
+    if (nextKeySet.has(key)) {
+      append(key);
+      continue;
+    }
+
+    const replacements = pathKeysByLegacyKey.get(key);
+    if (replacements?.size === 1) {
+      append([...replacements][0]);
+      continue;
+    }
+
+    if (isLegacyNameOrderKey(key)) {
+      append(key);
+    }
+  }
+
+  for (const key of nextKeys) {
+    append(key);
+  }
+  return merged;
+}
+
+function mergeReorderedTabsWithUnresolvedLegacyKeys(
+  currentOrder: string[],
+  tabs: EditorWindow[],
+): string[] {
+  const reorderedKeys = [...new Set(tabs.map(windowKey))];
+  const reorderedKeySet = new Set(reorderedKeys);
+  const pathKeysByLegacyKey = new Map<string, Set<string>>();
+  for (const tab of tabs) {
+    if (!tab.path) continue;
+    const key = legacyWindowKey(tab);
+    const pathKeys = pathKeysByLegacyKey.get(key) ?? new Set<string>();
+    pathKeys.add(windowKey(tab));
+    pathKeysByLegacyKey.set(key, pathKeys);
+  }
+  const unresolvedLegacyKeys = new Set(
+    currentOrder.filter(
+      (key) =>
+        isLegacyNameOrderKey(key) &&
+        pathKeysByLegacyKey.get(key)?.size !== 1,
+    ),
+  );
+  const merged: string[] = [];
+  const seen = new Set<string>();
+  let reorderedIndex = 0;
+  const append = (key: string) => {
+    if (seen.has(key)) return;
+    seen.add(key);
+    merged.push(key);
+  };
+
+  for (const key of currentOrder) {
+    if (unresolvedLegacyKeys.has(key)) {
+      append(key);
+    } else if (reorderedKeySet.has(key) && reorderedIndex < reorderedKeys.length) {
+      append(reorderedKeys[reorderedIndex]);
+      reorderedIndex += 1;
+    }
+  }
+  while (reorderedIndex < reorderedKeys.length) {
+    append(reorderedKeys[reorderedIndex]);
+    reorderedIndex += 1;
+  }
+  return merged;
+}
+
 export function useEditorWindows({
   dismissWaitingForWindow,
   syncWaitingTimer,
@@ -168,11 +277,22 @@ export function useEditorWindows({
           loadGroupColors(),
         ]);
         const migratedSavedTabs = migrateLegacySavedTabs(savedTabs, order, history);
+        tabOrderRef.current = order;
+        savedTabsRef.current = migratedSavedTabs;
+        const restoredTabs = sortWindowsByOrder(
+          reconcilePersistentTabs(migratedSavedTabs, []).tabs,
+          order,
+        );
+        windowsRef.current = restoredTabs;
+        setWindows(restoredTabs);
+        setTabColors(colors);
+        setGroups(grps);
+        setGroupAssignments(assigns);
+        setCollapsedGroups(new Set(collapsed));
+        setGroupColors(grpColors);
+
         const metadataPaths = [...new Set(
           migratedSavedTabs
-            .filter((tab) =>
-              !tab.branch || !tab.repository_id || !tab.repository_name
-            )
             .map((tab) => normalizeProjectPath(tab.path))
             .filter(Boolean),
         )];
@@ -187,16 +307,16 @@ export function useEditorWindows({
             console.error("Failed to load project metadata:", error);
           }
         }
-        tabOrderRef.current = order;
         savedTabsRef.current = initialSavedTabs;
+        const tabsWithMetadata = sortWindowsByOrder(
+          reconcilePersistentTabs(initialSavedTabs, []).tabs,
+          order,
+        );
+        windowsRef.current = tabsWithMetadata;
+        setWindows(tabsWithMetadata);
         if (savedTabsDiffer(initialSavedTabs, savedTabs)) {
           void saveSavedTabs(initialSavedTabs);
         }
-        setTabColors(colors);
-        setGroups(grps);
-        setGroupAssignments(assigns);
-        setCollapsedGroups(new Set(collapsed));
-        setGroupColors(grpColors);
         orderLoadedRef.current = true;
       })();
     }
@@ -237,7 +357,10 @@ export function useEditorWindows({
     }
 
     const sorted = sortWindowsByOrder(reconciled.tabs, tabOrderRef.current);
-    const newOrder = [...new Set(sorted.map((window) => windowKey(window)))];
+    const newOrder = mergeOrderWithUnresolvedLegacyKeys(
+      tabOrderRef.current,
+      sorted,
+    );
     if (stringListsDiffer(newOrder, tabOrderRef.current)) {
       tabOrderRef.current = newOrder;
       void saveTabOrder(newOrder);
@@ -276,10 +399,12 @@ export function useEditorWindows({
   const refreshWindows = useCallback(async () => {
     try {
       await ensureStateLoaded();
-      const snapshot = normalizeSnapshot(
-        await invoke<WindowsSnapshot | EditorWindow[]>("get_windows_snapshot"),
-      );
+      const payload = await invoke<WindowsSnapshot | EditorWindow[]>("get_windows_snapshot");
+      const snapshot = normalizeSnapshot(payload);
       void invoke("request_windows_refresh");
+      if (isAppliedStructuredSnapshot(payload, lastSnapshotRevisionRef.current)) {
+        return;
+      }
       lastSnapshotRevisionRef.current = Math.max(
         lastSnapshotRevisionRef.current,
         snapshot.revision,
@@ -297,9 +422,14 @@ export function useEditorWindows({
     }
 
     try {
-      const snapshot = normalizeSnapshot(
-        await invoke<WindowsSnapshot | EditorWindow[]>("get_windows_snapshot"),
-      );
+      const payload = await invoke<WindowsSnapshot | EditorWindow[]>("get_windows_snapshot");
+      const snapshot = normalizeSnapshot(payload);
+      if (
+        !Array.isArray(payload) &&
+        payload.revision < lastSnapshotRevisionRef.current
+      ) {
+        return;
+      }
 
       if (snapshot.active_id !== null && snapshot.windows.length > 0) {
         const frontmost = snapshot.windows.find((window) => window.id === snapshot.active_id);
@@ -547,7 +677,10 @@ export function useEditorWindows({
     const [moved] = newWindows.splice(fromIndex, 1);
     newWindows.splice(toIndex, 0, moved);
 
-    const newOrder = newWindows.map((w) => windowKey(w));
+    const newOrder = mergeReorderedTabsWithUnresolvedLegacyKeys(
+      tabOrderRef.current,
+      newWindows,
+    );
     tabOrderRef.current = newOrder;
     saveTabOrder(newOrder);
 
@@ -569,7 +702,10 @@ export function useEditorWindows({
     const currentWindows = windowsRef.current;
     const newWindows = visualOrder.map((i) => currentWindows[i]);
 
-    const newOrder = newWindows.map((w) => windowKey(w));
+    const newOrder = mergeReorderedTabsWithUnresolvedLegacyKeys(
+      tabOrderRef.current,
+      newWindows,
+    );
     tabOrderRef.current = newOrder;
     saveTabOrder(newOrder);
 
@@ -705,10 +841,12 @@ export function useEditorWindows({
   const fetchWindows = useCallback(async (): Promise<number> => {
     try {
       await ensureStateLoaded();
-      const snapshot = normalizeSnapshot(
-        await invoke<WindowsSnapshot | EditorWindow[]>("get_windows_snapshot"),
-      );
+      const payload = await invoke<WindowsSnapshot | EditorWindow[]>("get_windows_snapshot");
+      const snapshot = normalizeSnapshot(payload);
       void invoke("request_windows_refresh");
+      if (isAppliedStructuredSnapshot(payload, lastSnapshotRevisionRef.current)) {
+        return windowsRef.current.length;
+      }
       const result = snapshot.windows;
       lastSnapshotRevisionRef.current = Math.max(
         lastSnapshotRevisionRef.current,

--- a/src/hooks/useEditorWindows.ts
+++ b/src/hooks/useEditorWindows.ts
@@ -5,7 +5,7 @@ import { getCurrentWindow, PhysicalPosition } from "@tauri-apps/api/window";
 import { ask } from "@tauri-apps/plugin-dialog";
 import type { TFunction } from "i18next";
 import { TAB_BAR_HEIGHT, ALL_EDITOR_BUNDLE_IDS, EDITOR_DISPLAY_NAMES } from "../types/editor";
-import type { EditorWindow, WindowsSnapshot, GroupDefinition, GroupAssignment, ProjectEditorBundleId, SavedTab, TabColorMap } from "../types/editor";
+import type { EditorWindow, WindowsSnapshot, GroupDefinition, GroupAssignment, ProjectEditorBundleId, ProjectMetadata, SavedTab, TabColorMap } from "../types/editor";
 import {
   loadTabOrder,
   loadTabColors,
@@ -32,6 +32,7 @@ import {
 import {
   migrateSavedTabKeys,
   migrateLegacySavedTabs,
+  mergeProjectMetadata,
   reconcilePersistentTabs,
   savedTabKey,
   savedTabsDiffer,
@@ -166,7 +167,26 @@ export function useEditorWindows({
           loadCollapsedGroups(),
           loadGroupColors(),
         ]);
-        const initialSavedTabs = migrateLegacySavedTabs(savedTabs, order, history);
+        const migratedSavedTabs = migrateLegacySavedTabs(savedTabs, order, history);
+        const metadataPaths = [...new Set(
+          migratedSavedTabs
+            .filter((tab) =>
+              !tab.branch || !tab.repository_id || !tab.repository_name
+            )
+            .map((tab) => normalizeProjectPath(tab.path))
+            .filter(Boolean),
+        )];
+        let initialSavedTabs = migratedSavedTabs;
+        if (metadataPaths.length > 0) {
+          try {
+            const metadata = await invoke<ProjectMetadata[]>("get_project_metadata", {
+              paths: metadataPaths,
+            });
+            initialSavedTabs = mergeProjectMetadata(migratedSavedTabs, metadata);
+          } catch (error) {
+            console.error("Failed to load project metadata:", error);
+          }
+        }
         tabOrderRef.current = order;
         savedTabsRef.current = initialSavedTabs;
         if (savedTabsDiffer(initialSavedTabs, savedTabs)) {

--- a/src/hooks/useEditorWindows.ts
+++ b/src/hooks/useEditorWindows.ts
@@ -4,13 +4,16 @@ import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow, PhysicalPosition } from "@tauri-apps/api/window";
 import { ask } from "@tauri-apps/plugin-dialog";
 import type { TFunction } from "i18next";
-import { TAB_BAR_HEIGHT, ALL_EDITOR_BUNDLE_IDS } from "../types/editor";
-import type { EditorWindow, WindowsSnapshot, GroupDefinition, GroupAssignment, TabColorMap } from "../types/editor";
+import { TAB_BAR_HEIGHT, ALL_EDITOR_BUNDLE_IDS, EDITOR_DISPLAY_NAMES } from "../types/editor";
+import type { EditorWindow, WindowsSnapshot, GroupDefinition, GroupAssignment, ProjectEditorBundleId, SavedTab, TabColorMap } from "../types/editor";
 import {
   loadTabOrder,
   loadTabColors,
+  loadHistory,
+  loadSavedTabs,
   saveTabOrder,
   saveTabColors,
+  saveSavedTabs,
   windowKey,
   sortWindowsByOrder,
   loadGroups,
@@ -21,9 +24,18 @@ import {
   saveCollapsedGroups,
   loadGroupColors,
   saveGroupColors,
+  legacyWindowKey,
   migrateResolvedWindowKeys,
+  normalizeProjectPath,
   runtimeWindowKey,
 } from "../utils/store";
+import {
+  migrateSavedTabKeys,
+  migrateLegacySavedTabs,
+  reconcilePersistentTabs,
+  savedTabKey,
+  savedTabsDiffer,
+} from "../utils/persistentTabs";
 
 interface UseEditorWindowsParams {
   dismissWaitingForWindow: (window: EditorWindow) => void;
@@ -53,7 +65,13 @@ interface UseEditorWindowsReturn {
   syncActiveTab: () => Promise<void>;
   syncActiveTabRef: MutableRefObject<() => Promise<void>>;
   handleTabClick: (index: number) => void;
-  handleNewTab: () => Promise<void>;
+  handleNewTab: (bundleId?: ProjectEditorBundleId) => Promise<boolean>;
+  handleOpenProject: (path: string, bundleId: ProjectEditorBundleId) => Promise<boolean>;
+  handleOpenSavedTab: (
+    index: number,
+    bundleId: ProjectEditorBundleId,
+    groupId?: string,
+  ) => Promise<boolean>;
   handleCloseTab: (index: number) => Promise<void>;
   handleReorder: (from: number, to: number) => void;
   handleReorderByVisual: (visualOrder: number[]) => void;
@@ -80,8 +98,14 @@ function editorWindowListsDiffer(next: EditorWindow[], current: EditorWindow[]):
       previous.repository_name !== window.repository_name ||
       previous.bundle_id !== window.bundle_id ||
       previous.editor_name !== window.editor_name ||
-      previous.resolution !== window.resolution;
+      previous.resolution !== window.resolution ||
+      previous.is_open !== window.is_open ||
+      previous.open_error !== window.open_error;
   });
+}
+
+function stringListsDiffer(a: string[], b: string[]): boolean {
+  return a.length !== b.length || a.some((value, index) => value !== b[index]);
 }
 
 function normalizeSnapshot(payload: WindowsSnapshot | EditorWindow[]): WindowsSnapshot {
@@ -109,9 +133,12 @@ export function useEditorWindows({
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
   const [groupColors, setGroupColors] = useState<Record<string, string>>({});
   const windowsRef = useRef<EditorWindow[]>([]);
+  const liveWindowsRef = useRef<EditorWindow[]>([]);
+  const savedTabsRef = useRef<SavedTab[]>([]);
   const activeIndexRef = useRef<number>(0);
   const tabOrderRef = useRef<string[]>([]);
   const orderLoadedRef = useRef(false);
+  const stateLoadPromiseRef = useRef<Promise<void> | null>(null);
   const lastTabClickTimeRef = useRef<number>(0);
   const lastSnapshotRevisionRef = useRef<number>(-1);
 
@@ -124,13 +151,111 @@ export function useEditorWindows({
     activeIndexRef.current = activeIndex;
   }, [activeIndex]);
 
+  const ensureStateLoaded = useCallback(async () => {
+    if (orderLoadedRef.current) return;
+
+    if (!stateLoadPromiseRef.current) {
+      stateLoadPromiseRef.current = (async () => {
+        const [order, colors, savedTabs, history, grps, assigns, collapsed, grpColors] = await Promise.all([
+          loadTabOrder(),
+          loadTabColors(),
+          loadSavedTabs(),
+          loadHistory(),
+          loadGroups(),
+          loadGroupAssignments(),
+          loadCollapsedGroups(),
+          loadGroupColors(),
+        ]);
+        const initialSavedTabs = migrateLegacySavedTabs(savedTabs, order, history);
+        tabOrderRef.current = order;
+        savedTabsRef.current = initialSavedTabs;
+        if (savedTabsDiffer(initialSavedTabs, savedTabs)) {
+          void saveSavedTabs(initialSavedTabs);
+        }
+        setTabColors(colors);
+        setGroups(grps);
+        setGroupAssignments(assigns);
+        setCollapsedGroups(new Set(collapsed));
+        setGroupColors(grpColors);
+        orderLoadedRef.current = true;
+      })();
+    }
+
+    try {
+      await stateLoadPromiseRef.current;
+    } catch (error) {
+      stateLoadPromiseRef.current = null;
+      throw error;
+    }
+  }, []);
+
+  const applySnapshot = useCallback((snapshot: WindowsSnapshot): EditorWindow[] => {
+    const nextLiveWindows = snapshot.windows.map((window) => ({ ...window, is_open: true }));
+    const currentLiveWindows = liveWindowsRef.current;
+
+    const migratedOrder = migrateResolvedWindowKeys(
+      tabOrderRef.current,
+      currentLiveWindows,
+      nextLiveWindows,
+    );
+    if (stringListsDiffer(migratedOrder, tabOrderRef.current)) {
+      void saveTabOrder(migratedOrder);
+    }
+    tabOrderRef.current = migratedOrder;
+
+    const migratedSavedTabs = migrateSavedTabKeys(
+      savedTabsRef.current,
+      currentLiveWindows,
+      nextLiveWindows,
+    );
+    const reconciled = reconcilePersistentTabs(migratedSavedTabs, nextLiveWindows);
+    if (savedTabsDiffer(reconciled.savedTabs, savedTabsRef.current)) {
+      savedTabsRef.current = reconciled.savedTabs;
+      void saveSavedTabs(reconciled.savedTabs);
+    } else {
+      savedTabsRef.current = reconciled.savedTabs;
+    }
+
+    const sorted = sortWindowsByOrder(reconciled.tabs, tabOrderRef.current);
+    const newOrder = [...new Set(sorted.map((window) => windowKey(window)))];
+    if (stringListsDiffer(newOrder, tabOrderRef.current)) {
+      tabOrderRef.current = newOrder;
+      void saveTabOrder(newOrder);
+    }
+
+    const nextWindowKeys = new Set(nextLiveWindows.map(windowKey));
+    const nextRuntimeKeys = new Set(nextLiveWindows.map(runtimeWindowKey));
+    const disappeared = currentLiveWindows.filter(
+      (window) =>
+        window.path &&
+        !nextWindowKeys.has(windowKey(window)) &&
+        !nextRuntimeKeys.has(runtimeWindowKey(window)),
+    );
+    if (disappeared.length > 0) {
+      addToHistory(disappeared);
+    }
+
+    liveWindowsRef.current = nextLiveWindows;
+    const currentWindows = windowsRef.current;
+    windowsRef.current = sorted;
+    if (editorWindowListsDiffer(sorted, currentWindows)) {
+      setWindows(sorted);
+    }
+
+    if (sorted.length === 0) {
+      activeIndexRef.current = 0;
+      setActiveIndex(0);
+    } else if (activeIndexRef.current >= sorted.length) {
+      activeIndexRef.current = sorted.length - 1;
+      setActiveIndex(sorted.length - 1);
+    }
+
+    return sorted;
+  }, [addToHistory]);
+
   const refreshWindows = useCallback(async () => {
     try {
-      if (!orderLoadedRef.current) {
-        tabOrderRef.current = await loadTabOrder();
-        orderLoadedRef.current = true;
-      }
-
+      await ensureStateLoaded();
       const snapshot = normalizeSnapshot(
         await invoke<WindowsSnapshot | EditorWindow[]>("get_windows_snapshot"),
       );
@@ -139,51 +264,11 @@ export function useEditorWindows({
         lastSnapshotRevisionRef.current,
         snapshot.revision,
       );
-      const result = snapshot.windows;
-      const migratedOrder = migrateResolvedWindowKeys(
-        tabOrderRef.current,
-        windowsRef.current,
-        result,
-      );
-      if (migratedOrder.some((key, index) => key !== tabOrderRef.current[index])) {
-        void saveTabOrder(migratedOrder);
-      }
-      tabOrderRef.current = migratedOrder;
-      const sorted = sortWindowsByOrder(result, tabOrderRef.current);
-      const newOrder = sorted.map((w) => windowKey(w));
-      const orderChanged =
-        newOrder.length !== tabOrderRef.current.length ||
-        newOrder.some((key, i) => tabOrderRef.current[i] !== key);
-      if (orderChanged) {
-        tabOrderRef.current = newOrder;
-      }
-
-      const currentWindows = windowsRef.current;
-      const hasChanged = editorWindowListsDiffer(sorted, currentWindows);
-
-      if (hasChanged) {
-        // Skip clearing windows on transient AX API empty response
-        if (sorted.length === 0 && currentWindows.length > 0) {
-          return;
-        }
-
-        const newKeys = new Set(sorted.map(windowKey));
-        const disappeared = currentWindows.filter(
-          (w) => !newKeys.has(windowKey(w)) && w.path
-        );
-        if (disappeared.length > 0) {
-          addToHistory(disappeared);
-        }
-
-        setWindows(sorted);
-        if (sorted.length > 0 && activeIndexRef.current >= sorted.length) {
-          setActiveIndex(sorted.length - 1);
-        }
-      }
+      applySnapshot(snapshot);
     } catch (error) {
       console.error("Failed to get editor windows:", error);
     }
-  }, [addToHistory]);
+  }, [applySnapshot, ensureStateLoaded]);
 
   const syncActiveTab = useCallback(async () => {
     const timeSinceLastClick = Date.now() - lastTabClickTimeRef.current;
@@ -212,43 +297,172 @@ export function useEditorWindows({
     }
   }, [syncWaitingTimer]);
 
-  const handleTabClick = useCallback(
-    (index: number) => {
-      if (index === activeIndexRef.current) return;
-
+  const focusLiveWindow = useCallback(
+    async (window: EditorWindow, index: number) => {
       lastTabClickTimeRef.current = Date.now();
       setActiveIndex(index);
-      const window = windowsRef.current[index];
-      if (window) {
-        dismissWaitingForWindow(window);
-
-        invoke("focus_editor_window", { bundle_id: window.bundle_id, window_id: window.id })
-          .then(() =>
-            invoke("maximize_editor_window", {
-              bundle_id: window.bundle_id,
-              window_id: window.id,
-              tab_bar_height: TAB_BAR_HEIGHT,
-            })
-          )
-          .catch((error) => {
-            console.error("Failed to focus/maximize window:", error);
-          });
+      activeIndexRef.current = index;
+      dismissWaitingForWindow(window);
+      try {
+        await invoke("focus_editor_window", {
+          bundle_id: window.bundle_id,
+          window_id: window.id,
+        });
+        await invoke("maximize_editor_window", {
+          bundle_id: window.bundle_id,
+          window_id: window.id,
+          tab_bar_height: TAB_BAR_HEIGHT,
+        });
+        return true;
+      } catch (error) {
+        console.error("Failed to focus/maximize window:", error);
+        return false;
       }
     },
     [dismissWaitingForWindow]
   );
 
-  const handleNewTab = useCallback(async () => {
+  const handleTabClick = useCallback(
+    (index: number) => {
+      const window = windowsRef.current[index];
+      if (!window || window.is_open === false) return;
+      if (index === activeIndexRef.current) return;
+      void focusLiveWindow(window, index);
+    },
+    [focusLiveWindow]
+  );
+
+  const handleOpenProject = useCallback(
+    async (path: string, bundleId: ProjectEditorBundleId) => {
+      const normalizedPath = normalizeProjectPath(path);
+      const existingIndex = windowsRef.current.findIndex(
+        (window) =>
+          window.is_open !== false &&
+          window.bundle_id === bundleId &&
+          normalizeProjectPath(window.path) === normalizedPath,
+      );
+      if (existingIndex >= 0) {
+        return focusLiveWindow(windowsRef.current[existingIndex], existingIndex);
+      }
+
+      try {
+        await invoke("open_project_in_editor", {
+          bundle_id: bundleId,
+          path: normalizedPath,
+        });
+        setTimeout(() => refreshWindowsRef.current(), 1000);
+        return true;
+      } catch (error) {
+        console.error("Failed to open project:", error);
+        return false;
+      }
+    },
+    [focusLiveWindow],
+  );
+
+  const handleOpenSavedTab = useCallback(
+    async (
+      index: number,
+      bundleId: ProjectEditorBundleId,
+      displayedGroupId?: string,
+    ) => {
+      await ensureStateLoaded();
+      const savedWindow = windowsRef.current[index];
+      if (!savedWindow?.path) return false;
+      if (savedWindow.is_open !== false) {
+        return focusLiveWindow(savedWindow, index);
+      }
+
+      const sourceKey = windowKey(savedWindow);
+      const retargetedTab: SavedTab = {
+        name: savedWindow.name,
+        path: normalizeProjectPath(savedWindow.path),
+        branch: savedWindow.branch,
+        repository_id: savedWindow.repository_id,
+        repository_name: savedWindow.repository_name,
+        bundle_id: bundleId,
+        editor_name: EDITOR_DISPLAY_NAMES[bundleId],
+        resolution: savedWindow.resolution,
+      };
+      const targetKey = savedTabKey(retargetedTab);
+      const targetAlreadySaved = savedTabsRef.current.some(
+        (tab) => savedTabKey(tab) === targetKey && savedTabKey(tab) !== sourceKey,
+      );
+      let sourceReplaced = false;
+      const nextSavedTabs = savedTabsRef.current.flatMap((tab) => {
+        if (savedTabKey(tab) !== sourceKey) return [tab];
+        sourceReplaced = true;
+        return targetAlreadySaved ? [] : [retargetedTab];
+      });
+      if (!sourceReplaced && !targetAlreadySaved) {
+        nextSavedTabs.push(retargetedTab);
+      }
+
+      savedTabsRef.current = nextSavedTabs;
+      void saveSavedTabs(nextSavedTabs);
+
+      if (sourceKey !== targetKey) {
+        const targetAlreadyOrdered = tabOrderRef.current.includes(targetKey);
+        const nextOrder = tabOrderRef.current.flatMap((key) => {
+          if (key !== sourceKey) return [key];
+          return targetAlreadyOrdered ? [] : [targetKey];
+        });
+        tabOrderRef.current = [...new Set(nextOrder)];
+        void saveTabOrder(tabOrderRef.current);
+
+        setGroupAssignments((currentAssignments) => {
+          const sourceGroupId = displayedGroupId ?? (
+            Object.prototype.hasOwnProperty.call(currentAssignments, sourceKey)
+              ? currentAssignments[sourceKey]
+              : currentAssignments[legacyWindowKey(savedWindow)]
+          );
+          if (sourceGroupId === undefined) return currentAssignments;
+
+          const nextAssignments = { ...currentAssignments };
+          delete nextAssignments[sourceKey];
+          nextAssignments[targetKey] = sourceGroupId;
+          void saveGroupAssignments(nextAssignments);
+          return nextAssignments;
+        });
+      }
+
+      const reconciled = reconcilePersistentTabs(nextSavedTabs, liveWindowsRef.current);
+      const sorted = sortWindowsByOrder(reconciled.tabs, tabOrderRef.current);
+      windowsRef.current = sorted;
+      setWindows(sorted);
+
+      const targetIndex = sorted.findIndex((window) => windowKey(window) === targetKey);
+      if (targetIndex >= 0) {
+        activeIndexRef.current = targetIndex;
+        setActiveIndex(targetIndex);
+      }
+
+      const opened = await handleOpenProject(retargetedTab.path, bundleId);
+      if (!opened) {
+        const errorWindows = windowsRef.current.map((window) =>
+          windowKey(window) === targetKey ? { ...window, open_error: true } : window
+        );
+        windowsRef.current = errorWindows;
+        setWindows(errorWindows);
+      }
+      return opened;
+    },
+    [ensureStateLoaded, focusLiveWindow, handleOpenProject],
+  );
+
+  const handleNewTab = useCallback(async (selectedBundleId?: ProjectEditorBundleId) => {
     try {
-      const bundleId = currentBundleIdRef.current;
+      const bundleId = selectedBundleId ?? currentBundleIdRef.current;
       if (!bundleId) {
         console.warn("No bundle_id available, cannot open new editor window");
-        return;
+        return false;
       }
       await invoke("open_new_editor", { bundle_id: bundleId });
       setTimeout(() => refreshWindowsRef.current(), 1000);
+      return true;
     } catch (error) {
       console.error("Failed to open new editor:", error);
+      return false;
     }
   }, [currentBundleIdRef]);
 
@@ -256,17 +470,42 @@ export function useEditorWindows({
     async (index: number) => {
       const win = windowsRef.current[index];
       if (win) {
-        const ok = await ask(t("app.closeConfirm", { name: win.name || t("app.untitled") }), {
+        const confirmKey = win.is_open === false
+          ? "app.removeTabConfirm"
+          : "app.closeAndRemoveConfirm";
+        const ok = await ask(t(confirmKey, { name: win.name || t("app.untitled") }), {
           title: t("app.closeConfirmTitle"),
           kind: "warning",
         });
         if (!ok) return;
 
         try {
-          await invoke("close_editor_window", { bundle_id: win.bundle_id, window_id: win.id });
+          if (win.is_open !== false) {
+            await invoke("close_editor_window", { bundle_id: win.bundle_id, window_id: win.id });
+          }
+
+          const key = windowKey(win);
+          const nextSavedTabs = savedTabsRef.current.filter(
+            (savedTab) => savedTabKey(savedTab) !== key,
+          );
+          savedTabsRef.current = nextSavedTabs;
+          await saveSavedTabs(nextSavedTabs);
+
+          const nextOrder = tabOrderRef.current.filter((tabKey) => tabKey !== key);
+          tabOrderRef.current = nextOrder;
+          await saveTabOrder(nextOrder);
+
+          const nextWindows = windowsRef.current.filter((window) => windowKey(window) !== key);
+          windowsRef.current = nextWindows;
+          setWindows(nextWindows);
+          const nextActiveIndex = nextWindows.length === 0
+            ? 0
+            : Math.min(activeIndexRef.current, nextWindows.length - 1);
+          activeIndexRef.current = nextActiveIndex;
+          setActiveIndex(nextActiveIndex);
           setTimeout(() => refreshWindowsRef.current(), 500);
         } catch (error) {
-          console.error("Failed to close window:", error);
+          console.error("Failed to close or remove tab:", error);
         }
       }
     },
@@ -445,24 +684,7 @@ export function useEditorWindows({
 
   const fetchWindows = useCallback(async (): Promise<number> => {
     try {
-      if (!orderLoadedRef.current) {
-        const [order, colors, grps, assigns, collapsed, grpColors] = await Promise.all([
-          loadTabOrder(),
-          loadTabColors(),
-          loadGroups(),
-          loadGroupAssignments(),
-          loadCollapsedGroups(),
-          loadGroupColors(),
-        ]);
-        tabOrderRef.current = order;
-        setTabColors(colors);
-        setGroups(grps);
-        setGroupAssignments(assigns);
-        setCollapsedGroups(new Set(collapsed));
-        setGroupColors(grpColors);
-        orderLoadedRef.current = true;
-      }
-
+      await ensureStateLoaded();
       const snapshot = normalizeSnapshot(
         await invoke<WindowsSnapshot | EditorWindow[]>("get_windows_snapshot"),
       );
@@ -472,34 +694,10 @@ export function useEditorWindows({
         lastSnapshotRevisionRef.current,
         snapshot.revision,
       );
-      const migratedOrder = migrateResolvedWindowKeys(
-        tabOrderRef.current,
-        windowsRef.current,
-        result,
-      );
-      if (migratedOrder.some((key, index) => key !== tabOrderRef.current[index])) {
-        void saveTabOrder(migratedOrder);
-      }
-      tabOrderRef.current = migratedOrder;
-      const sorted = sortWindowsByOrder(result, tabOrderRef.current);
-      tabOrderRef.current = sorted.map((w) => windowKey(w));
+      const sorted = applySnapshot(snapshot);
 
-      const currentWindows = windowsRef.current;
-      const hasChanged = editorWindowListsDiffer(sorted, currentWindows);
-
-      if (hasChanged) {
-        // Skip clearing windows on transient AX API empty response
-        if (sorted.length === 0 && currentWindows.length > 0) {
-          return 0;
-        }
-        setWindows(sorted);
-        if (sorted.length > 0 && activeIndexRef.current >= sorted.length) {
-          setActiveIndex(sorted.length - 1);
-        }
-      }
-
-      if (sorted.length > 0) {
-        addToHistory(sorted);
+      if (result.length > 0) {
+        addToHistory(result);
       }
 
       return sorted.length;
@@ -507,10 +705,11 @@ export function useEditorWindows({
       console.error("Failed to fetch windows:", error);
       return 0;
     }
-  }, [addToHistory]);
+  }, [addToHistory, applySnapshot, ensureStateLoaded]);
 
   // Refs for callback functions to avoid stale closures in event listeners
   const refreshWindowsRef = useRef(refreshWindows);
+  const handleTabClickRef = useRef(handleTabClick);
   const handleCloseTabRef = useRef(handleCloseTab);
   const handleNewTabRef = useRef(handleNewTab);
   const syncActiveTabRef = useRef(syncActiveTab);
@@ -519,6 +718,9 @@ export function useEditorWindows({
   useEffect(() => {
     refreshWindowsRef.current = refreshWindows;
   }, [refreshWindows]);
+  useEffect(() => {
+    handleTabClickRef.current = handleTabClick;
+  }, [handleTabClick]);
   useEffect(() => {
     handleCloseTabRef.current = handleCloseTab;
   }, [handleCloseTab]);
@@ -558,7 +760,7 @@ export function useEditorWindows({
         if (isMounted) {
           const currentIndex = activeIndexRef.current;
           const win = windowsRef.current[currentIndex];
-          if (win) {
+          if (win?.is_open !== false) {
             invoke("close_editor_window", { bundle_id: win.bundle_id, window_id: win.id });
             setTimeout(() => refreshWindowsRef.current(), 500);
           }
@@ -568,20 +770,8 @@ export function useEditorWindows({
 
       const unlistenSwitch = await listen<number>("switch-to-tab", (event) => {
         if (isMounted && event.payload < windowsRef.current.length) {
-          setActiveIndex(event.payload);
-          activeIndexRef.current = event.payload;
+          handleTabClickRef.current(event.payload);
           syncWaitingTimer();
-          const win = windowsRef.current[event.payload];
-          if (win) {
-            invoke("focus_editor_window", { bundle_id: win.bundle_id, window_id: win.id }).then(
-              () =>
-                invoke("maximize_editor_window", {
-                  bundle_id: win.bundle_id,
-                  window_id: win.id,
-                  tab_bar_height: TAB_BAR_HEIGHT,
-                })
-            );
-          }
         }
       });
       cleanupFns.push(unlistenSwitch);
@@ -628,47 +818,13 @@ export function useEditorWindows({
         }
         lastSnapshotRevisionRef.current = event.payload.revision;
 
-        const migratedOrder = migrateResolvedWindowKeys(
-          tabOrderRef.current,
-          windowsRef.current,
-          event.payload.windows,
-        );
-        if (migratedOrder.some((key, index) => key !== tabOrderRef.current[index])) {
-          void saveTabOrder(migratedOrder);
-        }
-        tabOrderRef.current = migratedOrder;
-        const sorted = sortWindowsByOrder(event.payload.windows, tabOrderRef.current);
-        const newOrder = sorted.map((w) => windowKey(w));
-        const orderChanged =
-          newOrder.length !== tabOrderRef.current.length ||
-          newOrder.some((key, i) => tabOrderRef.current[i] !== key);
-        if (orderChanged) {
-          tabOrderRef.current = newOrder;
-        }
-
-        const currentWindows = windowsRef.current;
-        const windowsChanged = editorWindowListsDiffer(sorted, currentWindows);
-
-        if (windowsChanged) {
-          const newKeys = new Set(sorted.map(windowKey));
-          const disappeared = currentWindows.filter(
-            (w) => !newKeys.has(windowKey(w)) && w.path
-          );
-          if (disappeared.length > 0) {
-            addToHistory(disappeared);
-          }
-
-          setWindows(sorted);
-          if (sorted.length > 0 && activeIndexRef.current >= sorted.length) {
-            setActiveIndex(sorted.length - 1);
-          }
-        }
+        const sorted = applySnapshot(event.payload);
 
         // Map active_id (CGWindowID) → activeIndex in the sorted list.
         // Runs even when windows didn't change: Registry also emits on active change.
         const { active_id } = event.payload;
         if (active_id !== null && active_id !== undefined) {
-          const idx = sorted.findIndex((w) => w.id === active_id);
+          const idx = sorted.findIndex((w) => w.is_open !== false && w.id === active_id);
           if (idx >= 0 && idx !== activeIndexRef.current) {
             setActiveIndex(idx);
             activeIndexRef.current = idx;
@@ -685,7 +841,7 @@ export function useEditorWindows({
       isMounted = false;
       cleanupFns.forEach((fn) => fn());
     };
-  }, [syncWaitingTimer, isEditorActiveRef, isTabManagerActiveRef, isVisibleRef]);
+  }, [applySnapshot, syncWaitingTimer, isEditorActiveRef, isTabManagerActiveRef, isVisibleRef]);
 
   return {
     windows,
@@ -705,6 +861,8 @@ export function useEditorWindows({
     syncActiveTabRef,
     handleTabClick,
     handleNewTab,
+    handleOpenProject,
+    handleOpenSavedTab,
     handleCloseTab,
     handleReorder,
     handleReorderByVisual,

--- a/src/hooks/useHistory.test.ts
+++ b/src/hooks/useHistory.test.ts
@@ -1,5 +1,4 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
-import { invoke } from "@tauri-apps/api/core";
 import type { EditorWindow, HistoryEntry } from "../types/editor";
 import { MAX_HISTORY_ENTRIES } from "../types/editor";
 import { useHistory } from "./useHistory";
@@ -28,18 +27,13 @@ function makeWindow(overrides: Partial<EditorWindow> = {}): EditorWindow {
 function setup(historyEntries: HistoryEntry[] = []) {
   mockLoadHistory.mockResolvedValue(historyEntries);
 
-  const refreshWindowsRef = { current: vi.fn().mockResolvedValue(undefined) };
+  const { result, rerender, unmount } = renderHook(() => useHistory());
 
-  const { result, rerender, unmount } = renderHook(() =>
-    useHistory({ refreshWindowsRef })
-  );
-
-  return { result, rerender, unmount, refreshWindowsRef };
+  return { result, rerender, unmount };
 }
 
 describe("useHistory", () => {
   beforeEach(() => {
-    vi.mocked(invoke).mockReset();
     mockLoadHistory.mockClear();
     mockSaveHistory.mockClear();
   });
@@ -51,7 +45,11 @@ describe("useHistory", () => {
     const { result } = setup(entries);
 
     await waitFor(() => {
-      expect(result.current.history).toEqual(entries);
+      expect(result.current.history).toEqual([{
+        name: "proj",
+        path: "/path/proj",
+        timestamp: 1000,
+      }]);
     });
     expect(mockLoadHistory).toHaveBeenCalledOnce();
   });
@@ -62,6 +60,27 @@ describe("useHistory", () => {
     await waitFor(() => {
       expect(result.current.history).toEqual([]);
     });
+  });
+
+  it("deduplicates stored history by project path", async () => {
+    const entries: HistoryEntry[] = [
+      { name: "proj", path: "/path/proj", bundleId: "com.todesktop.230313mzl4w4u92", editorName: "Cursor", timestamp: 2000 },
+      { name: "proj", path: "/path/proj/", bundleId: "com.microsoft.VSCode", editorName: "VSCode", timestamp: 1000 },
+    ];
+    const { result } = setup(entries);
+
+    await waitFor(() => {
+      expect(result.current.history).toEqual([{
+        name: "proj",
+        path: "/path/proj",
+        timestamp: 2000,
+      }]);
+    });
+    expect(mockSaveHistory).toHaveBeenCalledWith([{
+      name: "proj",
+      path: "/path/proj",
+      timestamp: 2000,
+    }]);
   });
 
   describe("addToHistory", () => {
@@ -80,7 +99,7 @@ describe("useHistory", () => {
       expect(result.current.history).toHaveLength(1);
       expect(result.current.history[0].name).toBe("project-a");
       expect(result.current.history[0].path).toBe("/path/a");
-      expect(result.current.history[0].bundleId).toBe("com.microsoft.VSCode");
+      expect(result.current.history[0]).not.toHaveProperty("bundleId");
     });
 
     it("skips windows without path", async () => {
@@ -98,7 +117,7 @@ describe("useHistory", () => {
       expect(result.current.history).toHaveLength(0);
     });
 
-    it("deduplicates by path+bundleId", async () => {
+    it("deduplicates by path", async () => {
       const existing: HistoryEntry[] = [
         { name: "old-name", path: "/worktrees/one/proj", bundleId: "com.microsoft.VSCode", editorName: "VSCode", timestamp: 1000 },
       ];
@@ -108,13 +127,19 @@ describe("useHistory", () => {
         expect(result.current.history).toHaveLength(1);
       });
 
-      const win = makeWindow({ name: "proj", path: "/worktrees/one/proj" });
+      const win = makeWindow({
+        name: "proj",
+        path: "/worktrees/one/proj",
+        bundle_id: "com.todesktop.230313mzl4w4u92",
+        editor_name: "Cursor",
+      });
       act(() => {
         result.current.addToHistory([win]);
       });
 
       expect(result.current.history).toHaveLength(1);
       expect(result.current.history[0].name).toBe("proj");
+      expect(result.current.history[0]).not.toHaveProperty("bundleId");
     });
 
     it("keeps same-named worktrees as separate history entries", async () => {
@@ -177,43 +202,6 @@ describe("useHistory", () => {
       expect(mockSaveHistory).toHaveBeenCalledWith(
         expect.arrayContaining([expect.objectContaining({ name: "proj" })])
       );
-    });
-  });
-
-  describe("handleOpenFromHistory", () => {
-    it("invokes open_project_in_editor and refreshes windows", async () => {
-      vi.useFakeTimers();
-      vi.mocked(invoke).mockResolvedValue(undefined);
-
-      const entry: HistoryEntry = {
-        name: "proj",
-        path: "/path/proj",
-        bundleId: "com.microsoft.VSCode",
-        editorName: "VSCode",
-        timestamp: 1000,
-      };
-      const { result, refreshWindowsRef } = setup([entry]);
-
-      await vi.waitFor(() => {
-        expect(result.current.history).toHaveLength(1);
-      });
-
-      await act(async () => {
-        await result.current.handleOpenFromHistory(entry);
-      });
-
-      expect(invoke).toHaveBeenCalledWith("open_project_in_editor", {
-        bundle_id: "com.microsoft.VSCode",
-        path: "/path/proj",
-      });
-
-      // After 1500ms, refreshWindows should be called
-      act(() => {
-        vi.advanceTimersByTime(1500);
-      });
-      expect(refreshWindowsRef.current).toHaveBeenCalled();
-
-      vi.useRealTimers();
     });
   });
 

--- a/src/hooks/useHistory.ts
+++ b/src/hooks/useHistory.ts
@@ -1,12 +1,11 @@
 import { useEffect, useState, useCallback, useRef, type MutableRefObject } from "react";
-import { invoke } from "@tauri-apps/api/core";
-import { EDITOR_DISPLAY_NAMES, MAX_HISTORY_ENTRIES } from "../types/editor";
+import { MAX_HISTORY_ENTRIES } from "../types/editor";
 import type { EditorWindow, HistoryEntry } from "../types/editor";
-import { loadHistory, normalizeProjectPath, saveHistory } from "../utils/store";
-
-interface UseHistoryParams {
-  refreshWindowsRef: MutableRefObject<() => Promise<void>>;
-}
+import {
+  loadHistory,
+  normalizeProjectPath,
+  saveHistory,
+} from "../utils/store";
 
 interface UseHistoryReturn {
   history: HistoryEntry[];
@@ -15,11 +14,24 @@ interface UseHistoryReturn {
   showAddMenuRef: MutableRefObject<boolean>;
   setShowAddMenu: (show: boolean) => void;
   addToHistory: (disappeared: EditorWindow[]) => void;
-  handleOpenFromHistory: (entry: HistoryEntry) => Promise<void>;
   handleClearHistory: () => void;
 }
 
-export function useHistory({ refreshWindowsRef }: UseHistoryParams): UseHistoryReturn {
+function migrateHistory(entries: HistoryEntry[]): HistoryEntry[] {
+  const seen = new Set<string>();
+  return entries.flatMap((entry) => {
+    const path = normalizeProjectPath(entry.path);
+    if (seen.has(path)) return [];
+    seen.add(path);
+    return [{
+      name: entry.name,
+      path,
+      timestamp: entry.timestamp,
+    }];
+  });
+}
+
+export function useHistory(): UseHistoryReturn {
   const [history, setHistory] = useState<HistoryEntry[]>([]);
   const historyRef = useRef<HistoryEntry[]>([]);
   const [showAddMenu, setShowAddMenu] = useState(false);
@@ -37,8 +49,19 @@ export function useHistory({ refreshWindowsRef }: UseHistoryParams): UseHistoryR
   // Load history from store on startup
   useEffect(() => {
     loadHistory().then((entries) => {
-      setHistory(entries);
-      historyRef.current = entries;
+      const migrated = migrateHistory(entries);
+      setHistory(migrated);
+      historyRef.current = migrated;
+      if (
+        migrated.length !== entries.length ||
+        entries.some((entry, index) =>
+          Boolean(entry.bundleId) ||
+          Boolean(entry.editorName) ||
+          entry.path !== migrated[index]?.path
+        )
+      ) {
+        saveHistory(migrated);
+      }
     });
   }, []);
 
@@ -51,21 +74,13 @@ export function useHistory({ refreshWindowsRef }: UseHistoryParams): UseHistoryR
       for (const win of disappeared) {
         if (!win.path) continue;
 
-        const bundleId = win.bundle_id;
-        const editorName = EDITOR_DISPLAY_NAMES[bundleId] || win.editor_name || bundleId;
-
         updated = updated.filter(
-          (e) => !(
-            normalizeProjectPath(e.path) === normalizeProjectPath(win.path) &&
-            e.bundleId === bundleId
-          )
+          (entry) => normalizeProjectPath(entry.path) !== normalizeProjectPath(win.path)
         );
 
         updated.unshift({
           name: win.name,
           path: win.path,
-          bundleId,
-          editorName,
           timestamp: now,
         });
       }
@@ -80,21 +95,6 @@ export function useHistory({ refreshWindowsRef }: UseHistoryParams): UseHistoryR
     });
   }, []);
 
-  const handleOpenFromHistory = useCallback(
-    async (entry: HistoryEntry) => {
-      try {
-        await invoke("open_project_in_editor", {
-          bundle_id: entry.bundleId,
-          path: entry.path,
-        });
-        setTimeout(() => refreshWindowsRef.current(), 1500);
-      } catch (error) {
-        console.error("Failed to open project from history:", error);
-      }
-    },
-    [refreshWindowsRef]
-  );
-
   const handleClearHistory = useCallback(() => {
     setHistory([]);
     historyRef.current = [];
@@ -108,7 +108,6 @@ export function useHistory({ refreshWindowsRef }: UseHistoryParams): UseHistoryR
     showAddMenuRef,
     setShowAddMenu,
     addToHistory,
-    handleOpenFromHistory,
     handleClearHistory,
   };
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,13 +1,19 @@
 {
   "app": {
     "closeConfirm": "Close \"{{name}}\"?",
+    "closeAndRemoveConfirm": "Close \"{{name}}\" and remove its tab?",
+    "removeTabConfirm": "Remove the \"{{name}}\" tab?",
     "closeConfirmTitle": "Confirm",
     "notificationBody": "Generation complete ✅",
     "untitled": "Untitled"
   },
   "tabBar": {
     "newEditorTooltip": "Open new editor window (Cmd+Shift+T)",
-    "closeTooltip": "Close (Cmd+W)"
+    "closeTooltip": "Close (Cmd+W)",
+    "removeTooltip": "Remove tab",
+    "closedTooltip": "{{name}} (closed — click to open)",
+    "closedLabel": "Closed",
+    "openFailed": "Could not open in the editor"
   },
   "worktree": {
     "openBranches": "Open {{name}} branches",
@@ -73,7 +79,10 @@
     "quit": "Quit Editor Tab Manager"
   },
   "history": {
+    "chooseEditor": "Choose an editor",
+    "cancel": "Cancel",
     "newWindow": "New Window",
+    "openFailed": "Could not open with {{editor}}",
     "recentProjects": "Recent Projects",
     "empty": "No history",
     "clear": "Clear History",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1,13 +1,19 @@
 {
   "app": {
     "closeConfirm": "「{{name}}」を閉じますか？",
+    "closeAndRemoveConfirm": "「{{name}}」を閉じてタブから削除しますか？",
+    "removeTabConfirm": "「{{name}}」をタブから削除しますか？",
     "closeConfirmTitle": "確認",
     "notificationBody": "Generation complete ✅",
     "untitled": "Untitled"
   },
   "tabBar": {
     "newEditorTooltip": "新しいエディタウィンドウを開く (Cmd+Shift+T)",
-    "closeTooltip": "閉じる (Cmd+W)"
+    "closeTooltip": "閉じる (Cmd+W)",
+    "removeTooltip": "タブから削除",
+    "closedTooltip": "{{name}}（閉じています。クリックして開く）",
+    "closedLabel": "閉じています",
+    "openFailed": "エディタで開けませんでした"
   },
   "worktree": {
     "openBranches": "{{name}}のブランチを開く",
@@ -73,7 +79,10 @@
     "quit": "Editor Tab Managerを終了"
   },
   "history": {
+    "chooseEditor": "エディタを選択",
+    "cancel": "キャンセル",
     "newWindow": "新規ウィンドウ",
+    "openFailed": "{{editor}}で開けませんでした",
     "recentProjects": "最近のプロジェクト",
     "empty": "履歴はありません",
     "clear": "履歴をクリア",

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -14,6 +14,19 @@ export interface EditorWindow {
   bundle_id: string;
   editor_name: string;
   resolution?: "exact" | "inferred" | "unresolved";
+  is_open?: boolean;
+  open_error?: boolean;
+}
+
+export interface SavedTab {
+  name: string;
+  path: string;
+  branch?: string;
+  repository_id?: string;
+  repository_name?: string;
+  bundle_id: string;
+  editor_name: string;
+  resolution?: "exact" | "inferred" | "unresolved";
 }
 
 export interface WindowsSnapshot {
@@ -26,8 +39,8 @@ export interface WindowsSnapshot {
 export interface HistoryEntry {
   name: string;       // Project name
   path: string;       // File system path
-  bundleId: string;   // Editor bundle ID
-  editorName: string; // Editor display name
+  bundleId?: string;   // Legacy editor bundle ID
+  editorName?: string; // Legacy editor display name
   timestamp: number;  // Date.now()
 }
 
@@ -39,9 +52,17 @@ export const EDITOR_DISPLAY_NAMES: Record<string, string> = {
   "com.anthropic.claudefordesktop": "Claude",
 };
 
+export const PROJECT_EDITOR_BUNDLE_IDS = [
+  "com.microsoft.VSCode",
+  "com.todesktop.230313mzl4w4u92",
+  "dev.zed.Zed",
+] as const;
+
+export type ProjectEditorBundleId = (typeof PROJECT_EDITOR_BUNDLE_IDS)[number];
+
 export const ALL_EDITOR_BUNDLE_IDS = Object.keys(EDITOR_DISPLAY_NAMES);
 
-export const MAX_HISTORY_ENTRIES = 20;
+export const MAX_HISTORY_ENTRIES = 200;
 
 export interface EditorState {
   is_active: boolean;

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -19,6 +19,7 @@ export interface EditorWindow {
 }
 
 export interface SavedTab {
+  runtime_id?: string;
   name: string;
   path: string;
   branch?: string;

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -29,6 +29,13 @@ export interface SavedTab {
   resolution?: "exact" | "inferred" | "unresolved";
 }
 
+export interface ProjectMetadata {
+  path: string;
+  branch: string | null;
+  repository_id: string | null;
+  repository_name: string | null;
+}
+
 export interface WindowsSnapshot {
   revision: number;
   windows: EditorWindow[];

--- a/src/utils/persistentTabs.test.ts
+++ b/src/utils/persistentTabs.test.ts
@@ -100,6 +100,155 @@ describe("reconcilePersistentTabs", () => {
     ]);
   });
 
+  it("matches same-named unresolved worktrees by their saved runtime identity", () => {
+    const saved: SavedTab[] = [
+      {
+        runtime_id: "zed:100",
+        name: "project",
+        path: "/worktrees/one/project",
+        bundle_id: "dev.zed.Zed",
+        editor_name: "Zed",
+      },
+      {
+        runtime_id: "zed:200",
+        name: "project",
+        path: "/worktrees/two/project",
+        bundle_id: "dev.zed.Zed",
+        editor_name: "Zed",
+      },
+    ];
+    const live = [
+      makeWindow({
+        id: 200,
+        runtime_id: "zed:200",
+        name: "project",
+        path: "",
+        bundle_id: "dev.zed.Zed",
+        editor_name: "Zed",
+        resolution: "unresolved",
+      }),
+      makeWindow({
+        id: 100,
+        runtime_id: "zed:100",
+        name: "project",
+        path: "",
+        bundle_id: "dev.zed.Zed",
+        editor_name: "Zed",
+        resolution: "unresolved",
+      }),
+    ];
+
+    const result = reconcilePersistentTabs(saved, live);
+
+    expect(result.tabs).toHaveLength(2);
+    expect(result.tabs).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 100,
+        runtime_id: "zed:100",
+        path: "/worktrees/one/project",
+        is_open: true,
+      }),
+      expect.objectContaining({
+        id: 200,
+        runtime_id: "zed:200",
+        path: "/worktrees/two/project",
+        is_open: true,
+      }),
+    ]));
+  });
+
+  it("does not name-match one saved tab to multiple unresolved live windows", () => {
+    const saved: SavedTab[] = [{
+      name: "project",
+      path: "/projects/project",
+      bundle_id: "dev.zed.Zed",
+      editor_name: "Zed",
+    }];
+    const live = [
+      makeWindow({
+        id: 100,
+        runtime_id: "zed:100",
+        name: "project",
+        path: "",
+        bundle_id: "dev.zed.Zed",
+        editor_name: "Zed",
+        resolution: "unresolved",
+      }),
+      makeWindow({
+        id: 200,
+        runtime_id: "zed:200",
+        name: "project",
+        path: "",
+        bundle_id: "dev.zed.Zed",
+        editor_name: "Zed",
+        resolution: "unresolved",
+      }),
+    ];
+
+    const result = reconcilePersistentTabs(saved, live);
+
+    expect(result.tabs).toHaveLength(3);
+    expect(result.tabs.filter((tab) => tab.is_open === false)).toHaveLength(1);
+    expect(result.tabs.filter((tab) => tab.path === "")).toHaveLength(2);
+  });
+
+  it("does not name-match a remaining worktree after another matched by runtime identity", () => {
+    const saved: SavedTab[] = [
+      {
+        runtime_id: "zed:100",
+        name: "project",
+        path: "/worktrees/one/project",
+        bundle_id: "dev.zed.Zed",
+        editor_name: "Zed",
+      },
+      {
+        name: "project",
+        path: "/worktrees/two/project",
+        bundle_id: "dev.zed.Zed",
+        editor_name: "Zed",
+      },
+    ];
+    const live = [
+      makeWindow({
+        id: 100,
+        runtime_id: "zed:100",
+        name: "project",
+        path: "",
+        bundle_id: "dev.zed.Zed",
+        editor_name: "Zed",
+        resolution: "unresolved",
+      }),
+      makeWindow({
+        id: 300,
+        runtime_id: "zed:300",
+        name: "project",
+        path: "",
+        bundle_id: "dev.zed.Zed",
+        editor_name: "Zed",
+        resolution: "unresolved",
+      }),
+    ];
+
+    const result = reconcilePersistentTabs(saved, live);
+
+    expect(result.tabs).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        runtime_id: "zed:100",
+        path: "/worktrees/one/project",
+        is_open: true,
+      }),
+      expect.objectContaining({
+        path: "/worktrees/two/project",
+        is_open: false,
+      }),
+      expect.objectContaining({
+        runtime_id: "zed:300",
+        path: "",
+        is_open: true,
+      }),
+    ]));
+  });
+
   it("keeps an unresolved window separate when multiple saved tabs have its name", () => {
     const saved: SavedTab[] = [
       {
@@ -130,6 +279,16 @@ describe("reconcilePersistentTabs", () => {
     expect(result.tabs).toContainEqual(
       expect.objectContaining({ path: "", is_open: true }),
     );
+  });
+
+  it("stores a resolved live window runtime identity", () => {
+    const result = reconcilePersistentTabs([], [
+      makeWindow({ runtime_id: "vscode:10:20" }),
+    ]);
+
+    expect(result.savedTabs).toEqual([
+      expect.objectContaining({ runtime_id: "vscode:10:20" }),
+    ]);
   });
 });
 
@@ -170,6 +329,10 @@ describe("savedTabsDiffer", () => {
 
     expect(savedTabsDiffer([vscode], [cursor])).toBe(true);
     expect(savedTabsDiffer([vscode], [vscode])).toBe(false);
+    expect(savedTabsDiffer(
+      [{ ...vscode, runtime_id: "vscode:1" }],
+      [{ ...vscode, runtime_id: "vscode:2" }],
+    )).toBe(true);
   });
 });
 
@@ -196,7 +359,7 @@ describe("mergeProjectMetadata", () => {
     ]);
   });
 
-  it("preserves metadata already stored on the tab", () => {
+  it("updates stored metadata from the current project path", () => {
     const saved: SavedTab[] = [{
       name: "project",
       path: "/projects/project",
@@ -212,7 +375,36 @@ describe("mergeProjectMetadata", () => {
       branch: "other",
       repository_id: "/projects/other/.git",
       repository_name: "other",
-    }])).toEqual(saved);
+    }])).toEqual([{
+      ...saved[0],
+      branch: "other",
+      repository_id: "/projects/other/.git",
+      repository_name: "other",
+    }]);
+  });
+
+  it("clears stored metadata when the project is no longer a Git repository", () => {
+    const saved: SavedTab[] = [{
+      name: "project",
+      path: "/projects/project",
+      branch: "current",
+      repository_id: "/projects/project/.git",
+      repository_name: "project",
+      bundle_id: "com.microsoft.VSCode",
+      editor_name: "VSCode",
+    }];
+
+    expect(mergeProjectMetadata(saved, [{
+      path: "/projects/project",
+      branch: null,
+      repository_id: null,
+      repository_name: null,
+    }])).toEqual([{
+      ...saved[0],
+      branch: undefined,
+      repository_id: undefined,
+      repository_name: undefined,
+    }]);
   });
 });
 
@@ -248,7 +440,7 @@ describe("migrateLegacySavedTabs", () => {
     ]);
   });
 
-  it("does not rerun migration after saved tabs exist", () => {
+  it("adds missing path-based tabs while preserving saved tabs", () => {
     const existing: SavedTab[] = [{
       name: "project",
       path: "/projects/project",
@@ -260,6 +452,60 @@ describe("migrateLegacySavedTabs", () => {
       existing,
       ["com.microsoft.VSCode:/projects/other"],
       [],
-    )).toBe(existing);
+    )).toEqual([
+      existing[0],
+      {
+        name: "other",
+        path: "/projects/other",
+        bundle_id: "com.microsoft.VSCode",
+        editor_name: "VSCode",
+      },
+    ]);
+  });
+
+  it("restores a name-based legacy key from a unique matching history entry", () => {
+    const bundleId = "com.microsoft.VSCode";
+
+    expect(migrateLegacySavedTabs(
+      [],
+      [`${bundleId}:project`],
+      [{
+        name: "project",
+        path: "/projects/project",
+        bundleId,
+        editorName: "VSCode",
+        timestamp: 1,
+      }],
+    )).toEqual([{
+      name: "project",
+      path: "/projects/project",
+      bundle_id: bundleId,
+      editor_name: "VSCode",
+    }]);
+  });
+
+  it("does not guess a name-based legacy key with ambiguous history paths", () => {
+    const bundleId = "dev.zed.Zed";
+
+    expect(migrateLegacySavedTabs(
+      [],
+      [`${bundleId}:project`],
+      [
+        {
+          name: "project",
+          path: "/worktrees/one/project",
+          bundleId,
+          editorName: "Zed",
+          timestamp: 2,
+        },
+        {
+          name: "project",
+          path: "/worktrees/two/project",
+          bundleId,
+          editorName: "Zed",
+          timestamp: 1,
+        },
+      ],
+    )).toEqual([]);
   });
 });

--- a/src/utils/persistentTabs.test.ts
+++ b/src/utils/persistentTabs.test.ts
@@ -1,0 +1,221 @@
+import type { EditorWindow, SavedTab } from "../types/editor";
+import {
+  migrateLegacySavedTabs,
+  migrateSavedTabKeys,
+  reconcilePersistentTabs,
+  savedTabsDiffer,
+} from "./persistentTabs";
+
+function makeWindow(overrides: Partial<EditorWindow> = {}): EditorWindow {
+  return {
+    id: 1,
+    name: "project",
+    path: "/projects/project",
+    bundle_id: "com.microsoft.VSCode",
+    editor_name: "VSCode",
+    ...overrides,
+  };
+}
+
+describe("reconcilePersistentTabs", () => {
+  it("keeps a saved tab when its editor window is closed", () => {
+    const saved: SavedTab[] = [{
+      name: "project",
+      path: "/projects/project",
+      bundle_id: "com.microsoft.VSCode",
+      editor_name: "VSCode",
+    }];
+
+    const result = reconcilePersistentTabs(saved, []);
+
+    expect(result.tabs).toEqual([
+      expect.objectContaining({
+        path: "/projects/project",
+        bundle_id: "com.microsoft.VSCode",
+        is_open: false,
+      }),
+    ]);
+  });
+
+  it("stores the same project separately for different editors", () => {
+    const result = reconcilePersistentTabs([], [
+      makeWindow(),
+      makeWindow({
+        id: 2,
+        bundle_id: "com.todesktop.230313mzl4w4u92",
+        editor_name: "Cursor",
+      }),
+    ]);
+
+    expect(result.savedTabs).toHaveLength(2);
+    expect(result.tabs).toEqual([
+      expect.objectContaining({ bundle_id: "com.microsoft.VSCode", is_open: true }),
+      expect.objectContaining({
+        bundle_id: "com.todesktop.230313mzl4w4u92",
+        is_open: true,
+      }),
+    ]);
+  });
+
+  it("does not persist a window whose project path is unresolved", () => {
+    const unresolved = makeWindow({ path: "", resolution: "unresolved" });
+
+    const result = reconcilePersistentTabs([], [unresolved]);
+
+    expect(result.savedTabs).toEqual([]);
+    expect(result.tabs).toEqual([
+      expect.objectContaining({ path: "", is_open: true }),
+    ]);
+  });
+
+  it("matches a uniquely named unresolved window to its saved tab", () => {
+    const saved: SavedTab[] = [{
+      name: "wishlist",
+      path: "/projects/wishlist",
+      bundle_id: "dev.zed.Zed",
+      editor_name: "Zed",
+    }];
+    const unresolved = makeWindow({
+      id: 2,
+      runtime_id: "zed:2",
+      name: "wishlist",
+      path: "",
+      bundle_id: "dev.zed.Zed",
+      editor_name: "Zed",
+      resolution: "unresolved",
+    });
+
+    const result = reconcilePersistentTabs(saved, [unresolved]);
+
+    expect(result.savedTabs).toHaveLength(1);
+    expect(result.tabs).toEqual([
+      expect.objectContaining({
+        id: 2,
+        runtime_id: "zed:2",
+        path: "/projects/wishlist",
+        bundle_id: "dev.zed.Zed",
+        is_open: true,
+      }),
+    ]);
+  });
+
+  it("keeps an unresolved window separate when multiple saved tabs have its name", () => {
+    const saved: SavedTab[] = [
+      {
+        name: "project",
+        path: "/projects/one/project",
+        bundle_id: "dev.zed.Zed",
+        editor_name: "Zed",
+      },
+      {
+        name: "project",
+        path: "/projects/two/project",
+        bundle_id: "dev.zed.Zed",
+        editor_name: "Zed",
+      },
+    ];
+    const unresolved = makeWindow({
+      path: "",
+      bundle_id: "dev.zed.Zed",
+      editor_name: "Zed",
+      resolution: "unresolved",
+    });
+
+    const result = reconcilePersistentTabs(saved, [unresolved]);
+
+    expect(result.savedTabs).toHaveLength(2);
+    expect(result.tabs).toHaveLength(3);
+    expect(result.tabs.filter((tab) => tab.is_open === false)).toHaveLength(2);
+    expect(result.tabs).toContainEqual(
+      expect.objectContaining({ path: "", is_open: true }),
+    );
+  });
+});
+
+describe("migrateSavedTabKeys", () => {
+  it("replaces a saved path when the same runtime window resolves elsewhere", () => {
+    const current = makeWindow({
+      runtime_id: "cursor:42",
+      path: "/worktrees/old/project",
+    });
+    const next = makeWindow({
+      runtime_id: "cursor:42",
+      path: "/worktrees/current/project",
+    });
+    const saved: SavedTab[] = [{
+      name: current.name,
+      path: current.path,
+      bundle_id: current.bundle_id,
+      editor_name: current.editor_name,
+    }];
+
+    expect(migrateSavedTabKeys(saved, [current], [next])).toEqual([]);
+  });
+});
+
+describe("savedTabsDiffer", () => {
+  it("detects editor-specific tab changes", () => {
+    const vscode: SavedTab = {
+      name: "project",
+      path: "/projects/project",
+      bundle_id: "com.microsoft.VSCode",
+      editor_name: "VSCode",
+    };
+    const cursor = {
+      ...vscode,
+      bundle_id: "com.todesktop.230313mzl4w4u92",
+      editor_name: "Cursor",
+    };
+
+    expect(savedTabsDiffer([vscode], [cursor])).toBe(true);
+    expect(savedTabsDiffer([vscode], [vscode])).toBe(false);
+  });
+});
+
+describe("migrateLegacySavedTabs", () => {
+  it("restores path-based tabs in their previous order", () => {
+    const order = [
+      "com.todesktop.230313mzl4w4u92:/projects/beta",
+      "com.microsoft.VSCode:/projects/alpha",
+      "com.openai.codex:runtime:com.openai.codex:1:2",
+    ];
+
+    const result = migrateLegacySavedTabs([], order, [{
+      name: "beta-project",
+      path: "/projects/beta",
+      bundleId: "com.todesktop.230313mzl4w4u92",
+      editorName: "Cursor",
+      timestamp: 1,
+    }]);
+
+    expect(result).toEqual([
+      {
+        name: "beta-project",
+        path: "/projects/beta",
+        bundle_id: "com.todesktop.230313mzl4w4u92",
+        editor_name: "Cursor",
+      },
+      {
+        name: "alpha",
+        path: "/projects/alpha",
+        bundle_id: "com.microsoft.VSCode",
+        editor_name: "VSCode",
+      },
+    ]);
+  });
+
+  it("does not rerun migration after saved tabs exist", () => {
+    const existing: SavedTab[] = [{
+      name: "project",
+      path: "/projects/project",
+      bundle_id: "com.microsoft.VSCode",
+      editor_name: "VSCode",
+    }];
+
+    expect(migrateLegacySavedTabs(
+      existing,
+      ["com.microsoft.VSCode:/projects/other"],
+      [],
+    )).toBe(existing);
+  });
+});

--- a/src/utils/persistentTabs.test.ts
+++ b/src/utils/persistentTabs.test.ts
@@ -2,6 +2,7 @@ import type { EditorWindow, SavedTab } from "../types/editor";
 import {
   migrateLegacySavedTabs,
   migrateSavedTabKeys,
+  mergeProjectMetadata,
   reconcilePersistentTabs,
   savedTabsDiffer,
 } from "./persistentTabs";
@@ -169,6 +170,49 @@ describe("savedTabsDiffer", () => {
 
     expect(savedTabsDiffer([vscode], [cursor])).toBe(true);
     expect(savedTabsDiffer([vscode], [vscode])).toBe(false);
+  });
+});
+
+describe("mergeProjectMetadata", () => {
+  it("restores missing branch and repository fields from a saved path", () => {
+    const saved: SavedTab[] = [{
+      name: "project",
+      path: "/worktrees/feature/project",
+      bundle_id: "dev.zed.Zed",
+      editor_name: "Zed",
+    }];
+
+    expect(mergeProjectMetadata(saved, [{
+      path: "/worktrees/feature/project",
+      branch: "feature/saved-tab",
+      repository_id: "/projects/project/.git",
+      repository_name: "project",
+    }])).toEqual([
+      expect.objectContaining({
+        branch: "feature/saved-tab",
+        repository_id: "/projects/project/.git",
+        repository_name: "project",
+      }),
+    ]);
+  });
+
+  it("preserves metadata already stored on the tab", () => {
+    const saved: SavedTab[] = [{
+      name: "project",
+      path: "/projects/project",
+      branch: "current",
+      repository_id: "/projects/project/.git",
+      repository_name: "project",
+      bundle_id: "com.microsoft.VSCode",
+      editor_name: "VSCode",
+    }];
+
+    expect(mergeProjectMetadata(saved, [{
+      path: "/projects/project",
+      branch: "other",
+      repository_id: "/projects/other/.git",
+      repository_name: "other",
+    }])).toEqual(saved);
   });
 });
 

--- a/src/utils/persistentTabs.ts
+++ b/src/utils/persistentTabs.ts
@@ -2,6 +2,7 @@ import {
   EDITOR_DISPLAY_NAMES,
   type EditorWindow,
   type HistoryEntry,
+  type ProjectMetadata,
   type SavedTab,
 } from "../types/editor";
 import { normalizeProjectPath, runtimeWindowKey, windowKey } from "./store";
@@ -141,6 +142,25 @@ export function savedTabsDiffer(a: SavedTab[], b: SavedTab[]): boolean {
       tab.bundle_id !== other.bundle_id ||
       tab.editor_name !== other.editor_name ||
       tab.resolution !== other.resolution;
+  });
+}
+
+export function mergeProjectMetadata(
+  savedTabs: SavedTab[],
+  metadata: ProjectMetadata[],
+): SavedTab[] {
+  const metadataByPath = new Map(
+    metadata.map((item) => [normalizeProjectPath(item.path), item]),
+  );
+  return savedTabs.map((tab) => {
+    const item = metadataByPath.get(normalizeProjectPath(tab.path));
+    if (!item) return tab;
+    return {
+      ...tab,
+      branch: tab.branch ?? item.branch ?? undefined,
+      repository_id: tab.repository_id ?? item.repository_id ?? undefined,
+      repository_name: tab.repository_name ?? item.repository_name ?? undefined,
+    };
   });
 }
 

--- a/src/utils/persistentTabs.ts
+++ b/src/utils/persistentTabs.ts
@@ -1,0 +1,177 @@
+import {
+  EDITOR_DISPLAY_NAMES,
+  type EditorWindow,
+  type HistoryEntry,
+  type SavedTab,
+} from "../types/editor";
+import { normalizeProjectPath, runtimeWindowKey, windowKey } from "./store";
+
+export interface ReconciledTabs {
+  savedTabs: SavedTab[];
+  tabs: EditorWindow[];
+}
+
+export function savedTabKey(tab: SavedTab): string {
+  return `${tab.bundle_id}:${normalizeProjectPath(tab.path)}`;
+}
+
+function toSavedTab(window: EditorWindow): SavedTab {
+  return {
+    name: window.name,
+    path: normalizeProjectPath(window.path),
+    branch: window.branch,
+    repository_id: window.repository_id,
+    repository_name: window.repository_name,
+    bundle_id: window.bundle_id,
+    editor_name: window.editor_name,
+    resolution: window.resolution,
+  };
+}
+
+function toClosedWindow(tab: SavedTab): EditorWindow {
+  const key = savedTabKey(tab);
+  return {
+    id: 0,
+    runtime_id: `saved:${key}`,
+    ...tab,
+    path: normalizeProjectPath(tab.path),
+    is_open: false,
+  };
+}
+
+export function reconcilePersistentTabs(
+  savedTabs: SavedTab[],
+  liveWindows: EditorWindow[],
+): ReconciledTabs {
+  const savedByKey = new Map<string, SavedTab>();
+  for (const tab of savedTabs) {
+    if (!tab.path || !tab.bundle_id) continue;
+    savedByKey.set(savedTabKey(tab), {
+      ...tab,
+      path: normalizeProjectPath(tab.path),
+    });
+  }
+
+  const liveByKey = new Map<string, EditorWindow>();
+  const unresolvedWindows = liveWindows
+    .filter((window) => !window.path)
+    .map((window) => ({ ...window, is_open: true }));
+
+  for (const window of liveWindows) {
+    if (!window.path) continue;
+
+    const openWindow = { ...window, is_open: true };
+    const key = windowKey(window);
+    liveByKey.set(key, openWindow);
+    savedByKey.set(key, toSavedTab(window));
+  }
+
+  const unmatchedUnresolvedWindows: EditorWindow[] = [];
+  for (const openWindow of unresolvedWindows) {
+    const candidates = [...savedByKey.entries()].filter(
+      ([key, savedTab]) =>
+        !liveByKey.has(key) &&
+        savedTab.bundle_id === openWindow.bundle_id &&
+        savedTab.name === openWindow.name,
+    );
+    if (candidates.length !== 1) {
+      unmatchedUnresolvedWindows.push(openWindow);
+      continue;
+    }
+
+    const [key, savedTab] = candidates[0];
+    const matchedWindow: EditorWindow = {
+      ...savedTab,
+      ...openWindow,
+      path: savedTab.path,
+      branch: openWindow.branch ?? savedTab.branch,
+      repository_id: openWindow.repository_id ?? savedTab.repository_id,
+      repository_name: openWindow.repository_name ?? savedTab.repository_name,
+      resolution: savedTab.resolution ??
+        (openWindow.resolution === "unresolved" ? "inferred" : openWindow.resolution),
+    };
+    liveByKey.set(key, matchedWindow);
+    savedByKey.set(key, toSavedTab(matchedWindow));
+  }
+
+  const nextSavedTabs = [...savedByKey.values()];
+  const tabs = nextSavedTabs.map((tab) =>
+    liveByKey.get(savedTabKey(tab)) ?? toClosedWindow(tab)
+  );
+
+  return {
+    savedTabs: nextSavedTabs,
+    tabs: [...tabs, ...unmatchedUnresolvedWindows],
+  };
+}
+
+export function migrateSavedTabKeys(
+  savedTabs: SavedTab[],
+  currentWindows: EditorWindow[],
+  nextWindows: EditorWindow[],
+): SavedTab[] {
+  const nextByRuntimeKey = new Map(
+    nextWindows.map((window) => [runtimeWindowKey(window), window]),
+  );
+  const replacedKeys = new Set<string>();
+
+  for (const current of currentWindows) {
+    if (!current.path) continue;
+    const next = nextByRuntimeKey.get(runtimeWindowKey(current));
+    if (!next?.path) continue;
+    if (windowKey(current) !== windowKey(next)) {
+      replacedKeys.add(windowKey(current));
+    }
+  }
+
+  if (replacedKeys.size === 0) return savedTabs;
+  return savedTabs.filter((tab) => !replacedKeys.has(savedTabKey(tab)));
+}
+
+export function savedTabsDiffer(a: SavedTab[], b: SavedTab[]): boolean {
+  if (a.length !== b.length) return true;
+  return a.some((tab, index) => {
+    const other = b[index];
+    return !other ||
+      tab.name !== other.name ||
+      tab.path !== other.path ||
+      tab.branch !== other.branch ||
+      tab.repository_id !== other.repository_id ||
+      tab.repository_name !== other.repository_name ||
+      tab.bundle_id !== other.bundle_id ||
+      tab.editor_name !== other.editor_name ||
+      tab.resolution !== other.resolution;
+  });
+}
+
+export function migrateLegacySavedTabs(
+  savedTabs: SavedTab[],
+  tabOrder: string[],
+  history: HistoryEntry[],
+): SavedTab[] {
+  if (savedTabs.length > 0 || tabOrder.length === 0) return savedTabs;
+
+  const historyByKey = new Map(
+    history.flatMap((entry) => entry.bundleId
+      ? [[`${entry.bundleId}:${normalizeProjectPath(entry.path)}`, entry] as const]
+      : []),
+  );
+  const migrated: SavedTab[] = [];
+
+  for (const key of tabOrder) {
+    const pathSeparatorIndex = key.indexOf(":/");
+    if (pathSeparatorIndex < 0) continue;
+
+    const bundleId = key.slice(0, pathSeparatorIndex);
+    const path = normalizeProjectPath(key.slice(pathSeparatorIndex + 1));
+    const historyEntry = historyByKey.get(`${bundleId}:${path}`);
+    migrated.push({
+      name: historyEntry?.name || path.split("/").pop() || path,
+      path,
+      bundle_id: bundleId,
+      editor_name: historyEntry?.editorName || EDITOR_DISPLAY_NAMES[bundleId] || bundleId,
+    });
+  }
+
+  return migrated;
+}

--- a/src/utils/persistentTabs.ts
+++ b/src/utils/persistentTabs.ts
@@ -18,6 +18,7 @@ export function savedTabKey(tab: SavedTab): string {
 
 function toSavedTab(window: EditorWindow): SavedTab {
   return {
+    runtime_id: window.runtime_id,
     name: window.name,
     path: normalizeProjectPath(window.path),
     branch: window.branch,
@@ -33,8 +34,8 @@ function toClosedWindow(tab: SavedTab): EditorWindow {
   const key = savedTabKey(tab);
   return {
     id: 0,
-    runtime_id: `saved:${key}`,
     ...tab,
+    runtime_id: tab.runtime_id ?? `saved:${key}`,
     path: normalizeProjectPath(tab.path),
     is_open: false,
   };
@@ -67,20 +68,12 @@ export function reconcilePersistentTabs(
     savedByKey.set(key, toSavedTab(window));
   }
 
-  const unmatchedUnresolvedWindows: EditorWindow[] = [];
-  for (const openWindow of unresolvedWindows) {
-    const candidates = [...savedByKey.entries()].filter(
-      ([key, savedTab]) =>
-        !liveByKey.has(key) &&
-        savedTab.bundle_id === openWindow.bundle_id &&
-        savedTab.name === openWindow.name,
-    );
-    if (candidates.length !== 1) {
-      unmatchedUnresolvedWindows.push(openWindow);
-      continue;
-    }
-
-    const [key, savedTab] = candidates[0];
+  const unmatchedWindowIndices = new Set(unresolvedWindows.map((_, index) => index));
+  const availableSavedTabs = () => [...savedByKey.entries()].filter(
+    ([key]) => !liveByKey.has(key),
+  );
+  const matchWindow = (index: number, [key, savedTab]: [string, SavedTab]) => {
+    const openWindow = unresolvedWindows[index];
     const matchedWindow: EditorWindow = {
       ...savedTab,
       ...openWindow,
@@ -93,8 +86,52 @@ export function reconcilePersistentTabs(
     };
     liveByKey.set(key, matchedWindow);
     savedByKey.set(key, toSavedTab(matchedWindow));
+    unmatchedWindowIndices.delete(index);
+  };
+
+  for (const index of [...unmatchedWindowIndices]) {
+    const openWindow = unresolvedWindows[index];
+    if (!openWindow.runtime_id) continue;
+
+    const matchingLiveWindows = [...unmatchedWindowIndices].filter((candidateIndex) => {
+      const candidate = unresolvedWindows[candidateIndex];
+      return candidate.bundle_id === openWindow.bundle_id &&
+        candidate.runtime_id === openWindow.runtime_id;
+    });
+    const candidates = availableSavedTabs().filter(
+      ([, savedTab]) =>
+        savedTab.bundle_id === openWindow.bundle_id &&
+        savedTab.runtime_id === openWindow.runtime_id,
+    );
+    if (matchingLiveWindows.length === 1 && candidates.length === 1) {
+      matchWindow(index, candidates[0]);
+    }
   }
 
+  for (const index of [...unmatchedWindowIndices]) {
+    const openWindow = unresolvedWindows[index];
+    const matchingLiveWindows = unresolvedWindows.filter((candidate) => {
+      return candidate.bundle_id === openWindow.bundle_id &&
+        candidate.name === openWindow.name;
+    });
+    const matchingSavedTabs = [...savedByKey.entries()].filter(
+      ([, savedTab]) =>
+        savedTab.bundle_id === openWindow.bundle_id &&
+        savedTab.name === openWindow.name,
+    );
+    const candidates = matchingSavedTabs.filter(([key]) => !liveByKey.has(key));
+    if (
+      matchingLiveWindows.length === 1 &&
+      matchingSavedTabs.length === 1 &&
+      candidates.length === 1
+    ) {
+      matchWindow(index, candidates[0]);
+    }
+  }
+
+  const unmatchedUnresolvedWindows = unresolvedWindows.filter(
+    (_, index) => unmatchedWindowIndices.has(index),
+  );
   const nextSavedTabs = [...savedByKey.values()];
   const tabs = nextSavedTabs.map((tab) =>
     liveByKey.get(savedTabKey(tab)) ?? toClosedWindow(tab)
@@ -134,6 +171,7 @@ export function savedTabsDiffer(a: SavedTab[], b: SavedTab[]): boolean {
   return a.some((tab, index) => {
     const other = b[index];
     return !other ||
+      tab.runtime_id !== other.runtime_id ||
       tab.name !== other.name ||
       tab.path !== other.path ||
       tab.branch !== other.branch ||
@@ -157,9 +195,9 @@ export function mergeProjectMetadata(
     if (!item) return tab;
     return {
       ...tab,
-      branch: tab.branch ?? item.branch ?? undefined,
-      repository_id: tab.repository_id ?? item.repository_id ?? undefined,
-      repository_name: tab.repository_name ?? item.repository_name ?? undefined,
+      branch: item.branch ?? undefined,
+      repository_id: item.repository_id ?? undefined,
+      repository_name: item.repository_name ?? undefined,
     };
   });
 }
@@ -169,29 +207,64 @@ export function migrateLegacySavedTabs(
   tabOrder: string[],
   history: HistoryEntry[],
 ): SavedTab[] {
-  if (savedTabs.length > 0 || tabOrder.length === 0) return savedTabs;
+  if (tabOrder.length === 0) return savedTabs;
 
   const historyByKey = new Map(
     history.flatMap((entry) => entry.bundleId
       ? [[`${entry.bundleId}:${normalizeProjectPath(entry.path)}`, entry] as const]
       : []),
   );
-  const migrated: SavedTab[] = [];
+  const historyByLegacyName = new Map<string, Map<string, HistoryEntry>>();
+  for (const entry of history) {
+    if (!entry.bundleId || !entry.path) continue;
+    const key = `${entry.bundleId}:${entry.name}`;
+    const entriesByPath = historyByLegacyName.get(key) ??
+      new Map<string, HistoryEntry>();
+    entriesByPath.set(normalizeProjectPath(entry.path), entry);
+    historyByLegacyName.set(key, entriesByPath);
+  }
+  const migrated = [...savedTabs];
+  const migratedKeys = new Set(savedTabs.map(savedTabKey));
+  let changed = false;
+  const addMigratedTab = (tab: SavedTab) => {
+    const key = savedTabKey(tab);
+    if (migratedKeys.has(key)) return;
+    migratedKeys.add(key);
+    migrated.push(tab);
+    changed = true;
+  };
 
   for (const key of tabOrder) {
     const pathSeparatorIndex = key.indexOf(":/");
-    if (pathSeparatorIndex < 0) continue;
+    if (pathSeparatorIndex >= 0) {
+      const bundleId = key.slice(0, pathSeparatorIndex);
+      const path = normalizeProjectPath(key.slice(pathSeparatorIndex + 1));
+      const historyEntry = historyByKey.get(`${bundleId}:${path}`);
+      addMigratedTab({
+        name: historyEntry?.name || path.split("/").pop() || path,
+        path,
+        bundle_id: bundleId,
+        editor_name: historyEntry?.editorName || EDITOR_DISPLAY_NAMES[bundleId] || bundleId,
+      });
+      continue;
+    }
 
-    const bundleId = key.slice(0, pathSeparatorIndex);
-    const path = normalizeProjectPath(key.slice(pathSeparatorIndex + 1));
-    const historyEntry = historyByKey.get(`${bundleId}:${path}`);
-    migrated.push({
-      name: historyEntry?.name || path.split("/").pop() || path,
+    const separatorIndex = key.indexOf(":");
+    if (separatorIndex < 0) continue;
+    const bundleId = key.slice(0, separatorIndex);
+    const name = key.slice(separatorIndex + 1);
+    if (!name || name.startsWith("runtime:")) continue;
+
+    const historyEntries = historyByLegacyName.get(`${bundleId}:${name}`);
+    if (!historyEntries || historyEntries.size !== 1) continue;
+    const [path, historyEntry] = [...historyEntries.entries()][0];
+    addMigratedTab({
+      name: historyEntry.name,
       path,
       bundle_id: bundleId,
-      editor_name: historyEntry?.editorName || EDITOR_DISPLAY_NAMES[bundleId] || bundleId,
+      editor_name: historyEntry.editorName || EDITOR_DISPLAY_NAMES[bundleId] || bundleId,
     });
   }
 
-  return migrated;
+  return changed ? migrated : savedTabs;
 }

--- a/src/utils/store.test.ts
+++ b/src/utils/store.test.ts
@@ -311,4 +311,5 @@ describe("Store functions", () => {
       expect(result).toEqual([]);
     });
   });
+
 });

--- a/src/utils/store.ts
+++ b/src/utils/store.ts
@@ -1,6 +1,6 @@
 import { load } from "@tauri-apps/plugin-store";
 import type { Store } from "@tauri-apps/plugin-store";
-import type { EditorWindow, GroupAssignment, GroupDefinition, HistoryEntry, TabColorMap, TabLayout } from "../types/editor";
+import type { EditorWindow, GroupAssignment, GroupDefinition, HistoryEntry, SavedTab, TabColorMap, TabLayout } from "../types/editor";
 
 // Store instance (lazily initialized)
 let storePromise: Promise<Store> | null = null;
@@ -22,6 +22,7 @@ export const GROUPS_ASSIGNMENTS_KEY = "groups:assignments";
 export const GROUPS_COLLAPSED_KEY = "groups:collapsed";
 export const GROUPS_COLORS_KEY = "groups:colors";
 export const TAB_LAYOUT_KEY = "settings:tabLayout";
+export const SAVED_TABS_KEY = "tabs:saved";
 
 // Generic store helpers
 async function loadValue<T>(key: string, defaultValue: T): Promise<T> {
@@ -48,6 +49,8 @@ export const loadTabColors = () => loadValue<TabColorMap>(UNIFIED_COLOR_KEY, {})
 export const saveTabColors = (colors: TabColorMap) => saveValue(UNIFIED_COLOR_KEY, colors);
 export const loadHistory = () => loadValue<HistoryEntry[]>("history", []);
 export const saveHistory = (entries: HistoryEntry[]) => saveValue("history", entries);
+export const loadSavedTabs = () => loadValue<SavedTab[]>(SAVED_TABS_KEY, []);
+export const saveSavedTabs = (tabs: SavedTab[]) => saveValue(SAVED_TABS_KEY, tabs);
 export const loadGroups = () => loadValue<GroupDefinition[]>(GROUPS_DEFINITIONS_KEY, []);
 export const saveGroups = (groups: GroupDefinition[]) => saveValue(GROUPS_DEFINITIONS_KEY, groups);
 export const loadGroupAssignments = () => loadValue<GroupAssignment>(GROUPS_ASSIGNMENTS_KEY, {});


### PR DESCRIPTION
## Summary
- Persist tabs independently of editor window state and let users choose VS Code, Cursor, or Zed when reopening them
- Keep shared project history and preserve path-based group membership across editor changes
- Match same-named worktrees with runtime identity and restore repository and branch metadata
- Prevent stale or repeated window snapshots from overwriting newer tab state
- Serialize rapid project opens and keep pending paths stable until editor state catches up
- Open Zed projects in separate workspace windows
- Preserve the editor picker when handing off from the Add menu and restore its expanded position after app or display activation

## Test plan
- [x] `pnpm test:run` (190 tests)
- [x] `pnpm build`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` (61 tests)
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml`
- [x] `git diff --check`
- [x] Verified history and new-window mouse handoffs in the development app
- [x] Verified the expanded picker is restored after switching away and back

## Known issues
- Existing React `act(...)` warnings remain in the test output
- Existing `manual_c_str_literals` Clippy warnings remain in `notification.rs`
- The keyboard-only Add menu to editor picker handoff still needs manual confirmation
